### PR TITLE
support context and namespace kubectl flags

### DIFF
--- a/cmd/dracon/cmd/root.go
+++ b/cmd/dracon/cmd/root.go
@@ -25,7 +25,12 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
+// flags
+var (
+	cfgFile             string
+	kubernetesContext   string
+	kubernetesNamespace string
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -47,6 +52,8 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.dracon.yaml)")
+	rootCmd.PersistentFlags().StringVar(&kubernetesContext, "context", "", "Kubernetes Context")
+	rootCmd.PersistentFlags().StringVar(&kubernetesNamespace, "namespace", "", "Kubernetes Namespace")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/dracon/cmd/run.go
+++ b/cmd/dracon/cmd/run.go
@@ -58,7 +58,10 @@ var runCmd = &cobra.Command{
 		}
 
 		for _, doc := range resDocs["PipelineResource"] {
-			err = kubernetes.Apply(string(doc))
+			err = kubernetes.Apply(string(doc), &kubernetes.KubectlOpts{
+				Namespace: kubernetesNamespace,
+				Context:   kubernetesContext,
+			})
 			if err != nil {
 				log.Fatalf("Failed to apply templates: %s\n", err)
 				os.Exit(2)
@@ -66,7 +69,10 @@ var runCmd = &cobra.Command{
 		}
 
 		for _, doc := range resDocs["PipelineRun"] {
-			err = kubernetes.Apply(string(doc))
+			err = kubernetes.Apply(string(doc), &kubernetes.KubectlOpts{
+				Namespace: kubernetesNamespace,
+				Context:   kubernetesContext,
+			})
 			if err != nil {
 				log.Fatalf("Failed to apply templates: %s\n", err)
 				os.Exit(2)

--- a/cmd/dracon/cmd/setup.go
+++ b/cmd/dracon/cmd/setup.go
@@ -64,7 +64,10 @@ var setupCmd = &cobra.Command{
 		for k, docs := range resDocs {
 			if k != "PipelineRun" && k != "PipelineResource" {
 				for _, doc := range docs {
-					err = kubernetes.Apply(string(doc))
+					err = kubernetes.Apply(string(doc), &kubernetes.KubectlOpts{
+						Namespace: kubernetesNamespace,
+						Context:   kubernetesContext,
+					})
 					if err != nil {
 						log.Fatalf("Failed to apply templates :%s\n", err)
 					}

--- a/docs/getting-started/minikube.md
+++ b/docs/getting-started/minikube.md
@@ -41,21 +41,12 @@ A helper script that automates the below exists in `./scripts/minikube.sh`.
 
 ## Usage
 
-### Configure Kubectl
-
-Configure Kubectl to use the `minikube` context and `dracon` namespace by default:
-
-```bash
-$ kubectl config use-context minikube
-$ kubectl config set-context minikube --namespace=dracon
-```
-
 ### Setting up a Pipeline
 
 To setup an pipeline, you can execute:
 
 ```bash
-$ dracon setup --pipeline examples/pipelines/golang-project
+$ dracon --context minikube --namespace=dracon setup --pipeline examples/pipelines/golang-project
 ```
 
 ### Running a Pipeline
@@ -63,7 +54,7 @@ $ dracon setup --pipeline examples/pipelines/golang-project
 To run that example pipeline you can execute:
 
 ```bash
-$ dracon run --pipeline examples/pipelines/golang-project
+$ dracon --context minikube --namespace=dracon run --pipeline examples/pipelines/golang-project
 ```
 
 ### Inspecting a Pipeline

--- a/pkg/kubernetes/BUILD
+++ b/pkg/kubernetes/BUILD
@@ -8,3 +8,15 @@ go_library(
         "//third_party/go:pkg_errors",
     ],
 )
+
+go_test(
+    name = "kubernetes_test",
+    srcs = [
+        "apply_test.go",
+    ],
+    deps = [
+        ":kubernetes",
+        "//third_party/go:pkg_errors",
+        "//third_party/go:stretchr_testify",
+    ],
+)

--- a/pkg/kubernetes/apply.go
+++ b/pkg/kubernetes/apply.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os/exec"
@@ -8,16 +9,23 @@ import (
 	"github.com/pkg/errors"
 )
 
+// KubectlOpts represents options/flags to pass to kubectl
+type KubectlOpts struct {
+	Context   string
+	Namespace string
+}
+
 // Apply config using kubectl
-func Apply(config string) error {
-	cmd := exec.Command("kubectl", "apply", "-f", "-")
+func Apply(resources string, opts *KubectlOpts) error {
+	shCmd := GetCmd(opts)
+	cmd := exec.Command(shCmd[0], shCmd[1:]...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return errors.Wrap(err, "could not create stdin pipe")
 	}
 	go func() {
 		defer stdin.Close()
-		_, err := io.WriteString(stdin, config)
+		_, err := io.WriteString(stdin, resources)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -25,11 +33,25 @@ func Apply(config string) error {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, config)
+		return errors.Wrap(err, resources)
 	}
 	if !cmd.ProcessState.Success() {
 		return errors.Wrap(err, string(output))
 	}
 	log.Println(string(output))
 	return nil
+}
+
+// GetCmd returns the kubectl command
+func GetCmd(opts *KubectlOpts) []string {
+	cmd := []string{"kubectl", "apply", "-f", "-"}
+
+	if opts.Context != "" {
+		cmd = append(cmd, fmt.Sprintf(`--context=%s`, opts.Context))
+	}
+	if opts.Namespace != "" {
+		cmd = append(cmd, fmt.Sprintf(`--namespace=%s`, opts.Namespace))
+	}
+
+	return cmd
 }

--- a/pkg/kubernetes/apply_test.go
+++ b/pkg/kubernetes/apply_test.go
@@ -1,0 +1,28 @@
+package kubernetes_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/thought-machine/dracon/pkg/kubernetes"
+	"github.com/thought-machine/dracon/plz-out/go/src/github.com/stretchr/testify/assert"
+)
+
+func TestGetCmd(t *testing.T) {
+	var tests = []struct {
+		desc   string
+		inOpts kubernetes.KubectlOpts
+		outCmd string
+	}{
+		{"none", kubernetes.KubectlOpts{}, "kubectl apply -f -"},
+		{"namespace", kubernetes.KubectlOpts{Namespace: "default"}, `kubectl apply -f - --namespace=default`},
+		{"context", kubernetes.KubectlOpts{Context: "minikube"}, `kubectl apply -f - --context=minikube`},
+		{"namespace&context", kubernetes.KubectlOpts{Context: "minikube", Namespace: "default"}, `kubectl apply -f - --context=minikube --namespace=default`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			outCmd := strings.Join(kubernetes.GetCmd(&tt.inOpts), " ")
+			assert.Equal(t, tt.outCmd, outCmd)
+		})
+	}
+}

--- a/pkg/kubernetes/apply_test.go
+++ b/pkg/kubernetes/apply_test.go
@@ -1,27 +1,26 @@
-package kubernetes_test
+package kubernetes
 
 import (
 	"strings"
 	"testing"
 
-	"github.com/thought-machine/dracon/pkg/kubernetes"
-	"github.com/thought-machine/dracon/plz-out/go/src/github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetCmd(t *testing.T) {
 	var tests = []struct {
 		desc   string
-		inOpts kubernetes.KubectlOpts
+		inOpts KubectlOpts
 		outCmd string
 	}{
-		{"none", kubernetes.KubectlOpts{}, "kubectl apply -f -"},
-		{"namespace", kubernetes.KubectlOpts{Namespace: "default"}, `kubectl apply -f - --namespace=default`},
-		{"context", kubernetes.KubectlOpts{Context: "minikube"}, `kubectl apply -f - --context=minikube`},
-		{"namespace&context", kubernetes.KubectlOpts{Context: "minikube", Namespace: "default"}, `kubectl apply -f - --context=minikube --namespace=default`},
+		{"none", KubectlOpts{}, "kubectl apply -f -"},
+		{"namespace", KubectlOpts{Namespace: "default"}, `kubectl apply -f - --namespace=default`},
+		{"context", KubectlOpts{Context: "minikube"}, `kubectl apply -f - --context=minikube`},
+		{"namespace&context", KubectlOpts{Context: "minikube", Namespace: "default"}, `kubectl apply -f - --context=minikube --namespace=default`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			outCmd := strings.Join(kubernetes.GetCmd(&tt.inOpts), " ")
+			outCmd := strings.Join(GetCmd(&tt.inOpts), " ")
 			assert.Equal(t, tt.outCmd, outCmd)
 		})
 	}


### PR DESCRIPTION
This diff adds support for the `--context` and `--namespace` kubectl flags to dracon.