### PR TITLE
go 1.13 errors everywhere and error message from kubectl

### DIFF
--- a/pkg/kubernetes/BUILD
+++ b/pkg/kubernetes/BUILD
@@ -5,7 +5,6 @@ go_library(
     ],
     visibility = ["PUBLIC"],
     deps = [
-        "//third_party/go:pkg_errors",
     ],
 )
 
@@ -16,7 +15,6 @@ go_test(
     ],
     deps = [
         ":kubernetes",
-        "//third_party/go:pkg_errors",
         "//third_party/go:stretchr_testify",
     ],
 )

--- a/pkg/putil/BUILD
+++ b/pkg/putil/BUILD
@@ -8,6 +8,5 @@ go_library(
     deps = [
         "//pkg/genproto/v1",
         "//third_party/go:gogo_protobuf",
-        "//third_party/go:pkg_errors",
     ],
 )

--- a/pkg/putil/write.go
+++ b/pkg/putil/write.go
@@ -1,13 +1,13 @@
 package putil
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 	v1 "github.com/thought-machine/dracon/pkg/genproto/v1"
 )
 
@@ -56,7 +56,7 @@ func WriteResults(
 	}
 
 	if err := ioutil.WriteFile(outFile, outBytes, 0644); err != nil {
-		return errors.Wrapf(err, "could not write to file %s", outFile)
+		return fmt.Errorf("could not write to file '%s': %w", outFile, err)
 	}
 
 	log.Printf("wrote %d issues from to %s", len(issues), outFile)


### PR DESCRIPTION
This diff adds:
 - the use of go 1.13 errors everywhere
 - the cmd output error message returned from when `kubectl apply` fails