### PR TITLE
upgrade to ES 7

### DIFF
--- a/consumers/elasticsearch_c/BUILD
+++ b/consumers/elasticsearch_c/BUILD
@@ -9,7 +9,7 @@ go_binary(
     deps = [
         "//consumers",
         "//pkg/genproto/v1",
-        "//third_party/go:elastic_go-elasticsearch_v6",
+        "//third_party/go:elastic_go-elasticsearch_v7",
         "//third_party/go:golang_protobuf",
     ],
 )

--- a/consumers/elasticsearch_c/main.go
+++ b/consumers/elasticsearch_c/main.go
@@ -10,8 +10,8 @@ import (
 
 	//  TODO(hjenkins): Support multiple versions of ES
 	// elasticsearchv5 "github.com/elastic/go-elasticsearch/v5"
-	elasticsearchv6 "github.com/elastic/go-elasticsearch"
-	// elasticsearchv7 "github.com/elastic/go-elasticsearch/v7"
+	// elasticsearchv6 "github.com/elastic/go-elasticsearch/v6"
+	elasticsearchv7 "github.com/elastic/go-elasticsearch"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/thought-machine/dracon/consumers"
 	v1 "github.com/thought-machine/dracon/pkg/genproto/v1"
@@ -142,7 +142,7 @@ type esDocument struct {
 var esClient interface{}
 
 func getESClient() error {
-	es, err := elasticsearchv6.NewDefaultClient()
+	es, err := elasticsearchv7.NewDefaultClient()
 	if err != nil {
 		return err
 	}
@@ -164,10 +164,10 @@ func getESClient() error {
 	switch info.Version.Number[0] {
 	// case '5':
 	// 	esClient, err = elasticsearchv5.NewDefaultClient()
-	case '6':
-		esClient, err = elasticsearchv6.NewDefaultClient()
-	// case '7':
-	// 	esClient, err = elasticsearchv7.NewDefaultClient()
+	// case '6':
+	// 	esClient, err = elasticsearchv6.NewDefaultClient()
+	case '7':
+		esClient, err = elasticsearchv7.NewDefaultClient()
 	default:
 		err = fmt.Errorf("unsupported version %s", info.Version.Number)
 	}
@@ -180,10 +180,10 @@ func esPush(b []byte) error {
 	switch x := esClient.(type) {
 	// case *elasticsearchv5.Client:
 	// 	res, err = x.Index(esIndex, bytes.NewBuffer(b), x.Index.WithDocumentType("doc"))
-	case *elasticsearchv6.Client:
-		res, err = x.Index(esIndex, bytes.NewBuffer(b), x.Index.WithDocumentType("doc"))
-	// case *elasticsearchv7.Client:
-	// 	res, err = x.Index(esIndex, bytes.NewBuffer(b))
+	// case *elasticsearchv6.Client:
+	// 	res, err = x.Index(esIndex, bytes.NewBuffer(b), x.Index.WithDocumentType("doc"))
+	case *elasticsearchv7.Client:
+		res, err = x.Index(esIndex, bytes.NewBuffer(b))
 	default:
 		err = fmt.Errorf("unsupported client %T", esClient)
 	}

--- a/resources/persistence/elasticsearch-kibana/elasticsearch.yaml
+++ b/resources/persistence/elasticsearch-kibana/elasticsearch.yaml
@@ -14,20 +14,20 @@ spec:
         app: elasticsearch
     spec:
       containers:
-      - name: elasticsearch
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.8.5
-        env:
-        - name: discovery.type
-          value: single-node
-        ports:
-        - containerPort: 9200
-          name: client
-        - containerPort: 9300
-          name: nodes
-        volumeMounts:
-        - mountPath: /usr/share/elasticsearch/data
-          name: elasticsearch
-          subPath: es-data
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:7.6.0
+          env:
+            - name: discovery.type
+              value: single-node
+          ports:
+            - containerPort: 9200
+              name: client
+            - containerPort: 9300
+              name: nodes
+          volumeMounts:
+            - mountPath: /usr/share/elasticsearch/data
+              name: elasticsearch
+              subPath: es-data
   volumeClaimTemplates:
     - metadata:
         name: elasticsearch
@@ -46,9 +46,9 @@ metadata:
     service: elasticsearch
 spec:
   ports:
-  - port: 9200
-    name: client
-  - port: 9300
-    name: nodes
+    - port: 9200
+      name: client
+    - port: 9300
+      name: nodes
   selector:
     app: elasticsearch

--- a/resources/persistence/elasticsearch-kibana/kibana.yaml
+++ b/resources/persistence/elasticsearch-kibana/kibana.yaml
@@ -15,11 +15,11 @@ spec:
         app: kibana
     spec:
       containers:
-      - name: kibana
-        image: docker.elastic.co/kibana/kibana:6.8.5
-        ports:
-        - containerPort: 5601
-          name: webinterface
+        - name: kibana
+          image: docker.elastic.co/kibana/kibana:7.6.0
+          ports:
+            - containerPort: 5601
+              name: webinterface
 ---
 apiVersion: v1
 kind: Service
@@ -30,7 +30,7 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - port: 5601
-    name: webinterface
+    - port: 5601
+      name: webinterface
   selector:
     app: kibana

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -7,8 +7,21 @@ package(default_visibility = ["PUBLIC"])
 #     get = "github.com/elastic/go-elasticsearch",
 # )
 
+# TODO(hjenkins): Support multiple versions of ES
+# go_get(
+#     name = "elastic_go-elasticsearch_v6",
+#     get = "github.com/elastic/go-elasticsearch",
+#     install = [
+#         "",
+#         "esapi",
+#         "estransport",
+#         "internal/version",
+#     ],
+#     revision = "v6.8.2",
+# )
+
 go_get(
-    name = "elastic_go-elasticsearch_v6",
+    name = "elastic_go-elasticsearch_v7",
     get = "github.com/elastic/go-elasticsearch",
     install = [
         "",
@@ -16,15 +29,8 @@ go_get(
         "estransport",
         "internal/version",
     ],
-    revision = "v6.8.2",
+    revision = "v7.6.0",
 )
-
-# TODO(hjenkins): Support multiple versions of ES
-# go_get(
-#     name = "elastic_go-elasticsearch_v7",
-#     revision = "v7.4.1",
-#     get = "github.com/elastic/go-elasticsearch",
-# )
 
 go_get(
     name = "gogo_protobuf",


### PR DESCRIPTION
This PR upgrades our elasticsearch consumer to only support ES version 7 (the latest).