### PR TITLE
Update the publish image script to skip the metadata

### DIFF
--- a/scripts/publish-images.sh
+++ b/scripts/publish-images.sh
@@ -15,7 +15,7 @@ plz query alltargets //... --include docker-build | sed 's/$/_push/g' | plz -p -
 
 # Get all image tags
 plz query alltargets //... --include docker-build | sed 's/$/_fqn/g' | plz -p -v 2 --colour build
-all_tag_files=$(find . -type f -name "*_fqn")
+all_tag_files=$(find . -type f -name "*_fqn" | grep -v metadata)
 all_tags=""
 for tag_file in ${all_tag_files}; do
   tag=$(cat ${tag_file})


### PR DESCRIPTION
The publish images script gets confused due to binary metadata being produced by plz. This change modifies that script to skip any metadata files before publishing the images. 