### PR TITLE
scripts/*-images.sh: omit .target_* files from searches

### DIFF
--- a/scripts/dev-images.sh
+++ b/scripts/dev-images.sh
@@ -4,7 +4,7 @@ plz query alltargets //... --include docker-build | sed 's/$/_load/g' | plz -p -
 
 # get all tags
 plz query alltargets //... --include docker-build | sed 's/$/_fqn/g' | plz -p -v 2 --colour build
-all_tag_files=$(find . -type f -name "*_fqn")
+all_tag_files=$(find . -type f -name "*_fqn" -not -name '.target_*')
 all_tags=""
 for tag_file in ${all_tag_files}; do
   tag=$(cat ${tag_file})

--- a/scripts/publish-images.sh
+++ b/scripts/publish-images.sh
@@ -15,7 +15,7 @@ plz query alltargets //... --include docker-build | sed 's/$/_push/g' | plz -p -
 
 # Get all image tags
 plz query alltargets //... --include docker-build | sed 's/$/_fqn/g' | plz -p -v 2 --colour build
-all_tag_files=$(find . -type f -name "*_fqn" | grep -v metadata)
+all_tag_files=$(find . -type f -name "*_fqn" -not -name '.target_*' | grep -v metadata)
 all_tags=""
 for tag_file in ${all_tag_files}; do
   tag=$(cat ${tag_file})


### PR DESCRIPTION
Recent versions of Please output `.target_*` files, which causes problems for `dev-images.sh` and `publish-images.sh` when they search for files whose names end with `_fqn`. Omit the `.target_*` files from the searches these files perform.

Credit to @northdpole for figuring out what was causing `dev-images.sh` to fail with the latest version of Please 🙂 