### PR TITLE
Fix Gosec producer's Title and Description fields

### DIFF
--- a/producers/golang_gosec/main.go
+++ b/producers/golang_gosec/main.go
@@ -35,11 +35,11 @@ func parseIssues(out *GoSecOut) []*v1.Issue {
 		issues = append(issues, &v1.Issue{
 			Target:      fmt.Sprintf("%s:%v", r.File, r.Line),
 			Type:        r.RuleID,
-			Title:       r.Code,
+			Title:       r.Details,
 			Severity:    v1.Severity(v1.Severity_value[fmt.Sprintf("SEVERITY_%s", r.Severity)]),
 			Cvss:        0.0,
 			Confidence:  v1.Confidence(v1.Confidence_value[fmt.Sprintf("CONFIDENCE_%s", r.Confidence)]),
-			Description: r.Details,
+			Description: r.Code,
 		})
 	}
 	return issues

--- a/producers/golang_gosec/main_test.go
+++ b/producers/golang_gosec/main_test.go
@@ -41,11 +41,11 @@ func TestParseIssues(t *testing.T) {
 	expectedIssue := &v1.Issue{
 		Target:      "/tmp/source/foo.go:33",
 		Type:        "G304",
-		Title:       "ioutil.ReadFile(path)",
+		Title:       "Potential file inclusion via variable",
 		Severity:    v1.Severity_SEVERITY_MEDIUM,
 		Cvss:        0.0,
 		Confidence:  v1.Confidence_CONFIDENCE_HIGH,
-		Description: "Potential file inclusion via variable",
+		Description: "ioutil.ReadFile(path)",
 	}
 
 	assert.Equal(t, []*v1.Issue{expectedIssue}, issues)


### PR DESCRIPTION
This quick fix regards issue #49. Gosec producer's `Title` and `Description` fields should be swapped around (see info in #49)