### PR TITLE
Enricher: add database schema support

### DIFF
--- a/pkg/enrichment/db/BUILD
+++ b/pkg/enrichment/db/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//third_party/go:golang-migrate_migrate",
         "//third_party/go:protobuf",
         "//third_party/go:jmoiron_sqlx",
+        "//third_party/go:lib_pq",
         "//third_party/go:rakyll_statik",
     ],
 )

--- a/pkg/enrichment/db/db.go
+++ b/pkg/enrichment/db/db.go
@@ -1,13 +1,18 @@
 package db
 
 import (
+	"errors"
+	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/golang-migrate/migrate"
 	"github.com/golang-migrate/migrate/database/postgres"
 	bindata "github.com/golang-migrate/migrate/source/go_bindata"
+	"github.com/lib/pq"
 	"github.com/rakyll/statik/fs"
 
 	// Statik bindata for migrations
@@ -23,11 +28,29 @@ type DB struct {
 
 // NewDB returns a new DB for the enricher
 func NewDB(connStr string) (*DB, error) {
+	searchPath, err := getSchemaSearchPathFromConnStr(connStr)
+	if err != nil {
+		return nil, err
+	}
+
 	db, err := sqlx.Open("postgres", connStr)
 	if err != nil {
 		return nil, err
 	}
-	driver, err := postgres.WithInstance(db.DB, &postgres.Config{})
+
+	migrationsConfig := &postgres.Config{}
+	if searchPath != "" {
+		_, err := db.Exec(fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`,
+			pq.QuoteIdentifier(searchPath)))
+
+		if err != nil {
+			return nil, err
+		}
+
+		migrationsConfig.SchemaName = searchPath
+	}
+
+	driver, err := postgres.WithInstance(db.DB, migrationsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -62,4 +85,55 @@ func NewDB(connStr string) (*DB, error) {
 	}
 
 	return &DB{db}, nil
+}
+
+// getSchemaSearchPathFromConnStr extracts the database schema component from a
+// PostgreSQL connection string; if no schema was specified, the empty string is
+// returned
+func getSchemaSearchPathFromConnStr(connStr string) (string, error) {
+	url, err := url.Parse(connStr)
+
+	if err == nil && url.Scheme == "postgres" {
+		return getSchemaSearchPathFromURL(url)
+	} else {
+		return getSchemaSearchPathFromKV(connStr)
+	}
+}
+
+// getSchemaSearchPathFromURL extracts the schema search path component from a
+// PostgreSQL connection URL; if no search path is specified, the empty string
+// is returned
+func getSchemaSearchPathFromURL(connURL *url.URL) (string, error) {
+	path, found := connURL.Query()["search_path"]
+	if !found {
+		return "", nil
+	}
+
+	if len(path) == 0 {
+		return "", nil
+	} else if len(path) == 1 {
+		return path[0], nil
+	} else {
+		return "", errors.New("Multiple search_paths defined in database connection DSN")
+	}
+}
+
+// getSchemaSearchPathFromKV extracts the schema search path component from a
+// PostgreSQL keyword/value connection string; if no search path is specified,
+// the empty string is returned
+func getSchemaSearchPathFromKV(kvStr string) (string, error) {
+	var path string
+
+	for _, pair := range strings.Fields(kvStr) {
+		elems := strings.SplitN(pair, "=", 2)
+		if elems[0] == "search_path" {
+			if path != "" {
+				return "", errors.New("Multiple search_paths defined in database connection DSN")
+			}
+
+			path = elems[1]
+		}
+	}
+
+	return path, nil
 }


### PR DESCRIPTION
When the enricher connects to the database, check for the existence of a schema search path (`search_path`) in the connection string and perform the following actions if one is found:

* create a schema with the name given by the value of `search_path` if it doesn't already exist;
* configure the migrations instance to use the schema with the name given by the value of `search_path`.

This allows for the easy partitioning of enrichment data for different pipelines.