### PR TITLE
Add GNU Tar to Git source container

### DIFF
--- a/source/git/Dockerfile
+++ b/source/git/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
 
-RUN apk add --update --no-cache git openssh-client
+RUN apk add --update --no-cache git openssh-client tar
 
 COPY git.sh /git.sh


### PR DESCRIPTION
To facilitate fetching the remote codebase via `git archive`, add GNU Tar to the Git source container (BusyBox's `tar` implementation has an insufficiently powerful `--exclude` option).