### PR TITLE
TSLint Producer, for the security rules

### DIFF
--- a/producers/typescript_tslint/BUILD
+++ b/producers/typescript_tslint/BUILD
@@ -1,0 +1,37 @@
+subinclude("@third_party/subrepos/pleasings//docker")
+
+go_binary(
+    name = "typescript_tslint",
+    srcs = [
+        "main.go",
+    ],
+    deps = [
+        "//api/proto:v1",
+        "//producers",
+        "//producers/typescript_tslint/types:tslint-issue"
+
+    ],
+)
+
+go_test(
+    name = "typescript_tslint_test",
+    srcs = [
+        "main.go",
+        "main_test.go",
+    ],
+    deps = [
+        "//api/proto:v1",
+        "//producers",
+        "//third_party/go:stretchr_testify",
+        "//producers/typescript_tslint/types:tslint-issue"
+    ],
+)
+
+docker_image(
+    name = "dracon-producer-tslint",
+    srcs = [
+        ":typescript_tslint",
+    ],
+    base_image = "//build/docker:dracon-base-go",
+    image = "dracon-producer-gosec",
+)

--- a/producers/typescript_tslint/BUILD
+++ b/producers/typescript_tslint/BUILD
@@ -33,5 +33,5 @@ docker_image(
         ":typescript_tslint",
     ],
     base_image = "//build/docker:dracon-base-go",
-    image = "dracon-producer-gosec",
+    image = "dracon-producer-tslint",
 )

--- a/producers/typescript_tslint/Dockerfile
+++ b/producers/typescript_tslint/Dockerfile
@@ -1,0 +1,5 @@
+FROM //build/docker:dracon-base-go
+
+COPY typescript_tslint /parse
+
+ENTRYPOINT ["/parse"]

--- a/producers/typescript_tslint/main.go
+++ b/producers/typescript_tslint/main.go
@@ -21,7 +21,7 @@ func main() {
 	}
 	issues := parseIssues(results)
 	if err := producers.WriteDraconOut(
-		"gosec",
+		"tslint",
 		issues,
 	); err != nil {
 		log.Fatal(err)

--- a/producers/typescript_tslint/main.go
+++ b/producers/typescript_tslint/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
+	types "github.com/thought-machine/dracon/producers/typescript_tslint/types/tslint-issue"
+
+	"github.com/thought-machine/dracon/producers"
+)
+
+func main() {
+	if err := producers.ParseFlags(); err != nil {
+		log.Fatal(err)
+	}
+	var results []types.TSLintIssue
+	if err := producers.ParseInFileJSON(&results); err != nil {
+		log.Fatal(err)
+	}
+	issues := parseIssues(results)
+	if err := producers.WriteDraconOut(
+		"gosec",
+		issues,
+	); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func parseIssues(out []types.TSLintIssue) []*v1.Issue {
+	issues := []*v1.Issue{}
+	for _, r := range out {
+
+		bytes, err := json.Marshal(r)
+		if err != nil {
+			log.Print("Couldn't write issue ", fmt.Sprintf("%s:%v-%v", r.Name, r.StartPosition.Line, r.EndPosition.Line))
+		}
+
+		issues = append(issues, &v1.Issue{
+			Target:      fmt.Sprintf("%s:%v-%v", r.Name, r.StartPosition.Line, r.EndPosition.Line),
+			Type:        r.RuleName,
+			Title:       r.Failure,
+			Severity:    v1.Severity_SEVERITY_MEDIUM,
+			Cvss:        0.0,
+			Confidence:  v1.Confidence_CONFIDENCE_MEDIUM,
+			Description: string(bytes),
+		})
+	}
+	return issues
+}

--- a/producers/typescript_tslint/main_test.go
+++ b/producers/typescript_tslint/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
+	types "github.com/thought-machine/dracon/producers/typescript_tslint/types/tslint-issue"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const exampleOutput = `
+[
+	{
+	"endPosition": {
+	  "character": 63,
+	  "line": 21,
+	  "position": 774
+	},
+	"failure": "== should be ===",
+	"fix": [
+	  {
+		"innerStart": 760,
+		"innerLength": 6,
+		"innerText": ""
+	  },
+	  {
+		"innerStart": 773,
+		"innerLength": 1,
+		"innerText": "[]"
+	  }
+	],
+	"name": "/foo/bar/js/types/File.ts",
+	"ruleName": "triple-equals",
+	"ruleSeverity": "error",
+	"startPosition": {
+	  "character": 49,
+	  "line": 21,
+	  "position": 760
+	}
+  },
+  {
+	"endPosition": {
+	  "character": 63,
+	  "line": 23,
+	  "position": 774
+	},
+	"failure": "fail title",
+	"name": "/some/path/foo/types/File.ts",
+	"ruleName": "rule-name",
+	"ruleSeverity": "error",
+	"startPosition": {
+	  "character": 49,
+	  "line": 20,
+	  "position": 760
+	}
+  }
+  ]`
+
+func TestParseIssues(t *testing.T) {
+	var results []types.TSLintIssue
+	err := json.Unmarshal([]byte(exampleOutput), &results)
+	assert.Nil(t, err)
+	issues := parseIssues(results)
+
+	desc, _ := json.Marshal(results[0])
+	expectedIssue := &v1.Issue{
+		Target:      "/foo/bar/js/types/File.ts:21-21",
+		Type:        "triple-equals",
+		Title:       "== should be ===",
+		Severity:    v1.Severity_SEVERITY_MEDIUM,
+		Cvss:        0.0,
+		Confidence:  v1.Confidence_CONFIDENCE_MEDIUM,
+		Description: string(desc),
+	}
+	desc, _ = json.Marshal(results[1])
+	issue2 := &v1.Issue{
+		Target:      "/some/path/foo/types/File.ts:20-23",
+		Type:        "rule-name",
+		Title:       "fail title",
+		Severity:    v1.Severity_SEVERITY_MEDIUM,
+		Cvss:        0.0,
+		Confidence:  v1.Confidence_CONFIDENCE_MEDIUM,
+		Description: string(desc),
+	}
+	assert.Equal(t, expectedIssue, issues[0])
+	assert.Equal(t, issue2, issues[1])
+}

--- a/producers/typescript_tslint/types/BUILD
+++ b/producers/typescript_tslint/types/BUILD
@@ -1,0 +1,9 @@
+
+go_library(
+    name = "tslint-issue",
+    srcs = [
+        "tslint-issue.go",
+    ],
+    visibility = ["//producers/typescript_tslint/..."]
+
+)

--- a/producers/typescript_tslint/types/tslint-issue.go
+++ b/producers/typescript_tslint/types/tslint-issue.go
@@ -1,0 +1,17 @@
+package types
+
+// Position represents where in the file the finding is located
+type Position struct {
+	Character int `json:"character"`
+	Line      int `"json:line"`
+	Position  int `"json:position"`
+}
+
+// TSLintIssue represents a TSLint Result
+type TSLintIssue struct {
+	RuleName      string   `json:"ruleName"`
+	Failure       string   `json:"failure"`
+	Name          string   `json:"name"`
+	StartPosition Position `json:"startPosition"`
+	EndPosition   Position `json:"endPosition"`
+}


### PR DESCRIPTION
[TSLint](https://palantir.github.io/tslint/usage/cli/) has a [security rules plugin ](https://github.com/webschik/tslint-config-security). In order to allow dracon to scan Typescript files it makes sense to integrate a tslint parser.

This pull request does so