### PR TITLE
Pin please to v15.5.0

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -5,8 +5,8 @@
 ;
 ; Or you can uncomment the following to pin everyone to a particular version;
 ; when you change it all users will automatically get updated.
-; [please]
-; version = 14.1.7
+[please]
+version = 15.5.0
 
 [buildconfig]
 default-docker-repo = index.docker.io/thoughtmachine


### PR DESCRIPTION
This PR pins the please.build version to v15.5.0 as the most recent build (v15.6.0) breaks our Go builds.