### PR TITLE
Automatically push docker images during release CI/CD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,3 +23,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./pleasew run //scripts:pre-release
+      
+      - name: Publish Docker images
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: ./pleasew run //scripts:publish-images

--- a/docs/contributers/RELEASES.md
+++ b/docs/contributers/RELEASES.md
@@ -19,11 +19,10 @@ This lets us use `git desribe` to give us a descriptive version from any commit 
 
 ## Creating a Release
 
-1. Tag the commit you would like to release from `master` and push the tags:
+1. Tag the commit you would like to release from `master` and push the tags. This will trigger a GitHub workflow that creates a pre-release and pushes Docker images:
    ```
    git fetch --tags
    git tag --annotate <version> --message "<version>"
    git push origin --tags
    ```
-2. Build and publish the release Docker images to Docker Hub by running `./pleasew run //scripts:publish-images`
-3. In the GitHub web interface, you can then promote the new pre-release to a release
+2. Once satisfied, promote the new pre-release to a release.

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+git fetch --tags --force
 version=$(git describe --always)
 
 github_api_version="application/vnd.github.v3+json"


### PR DESCRIPTION
This PR adds the `./pleasew run //scripts:publish-images` to the `release` workflow so that Docker images are automatically pushed via CI/CD for each release. I have added the following secrets to the repository's actions for this to work:
- `DOCKERHUB_USERNAME`: `vjftw` (my Docker Hub account).
- `DOCKERHUB_PASSWORD`: A unique secret access token only used for this repository's GitHub Actions. (https://docs.docker.com/docker-hub/access-tokens/)

From the "Secrets" page in "Settings" for this repository:
> Secrets are environment variables that are encrypted and only exposed to selected actions. Anyone with collaborator access to this repository can use these secrets in a workflow.
> Secrets are not passed to workflows that are triggered by a pull request from a fork.