### PR TITLE
Add jq to gosec producer container

### DIFF
--- a/producers/golang_gosec/Dockerfile
+++ b/producers/golang_gosec/Dockerfile
@@ -1,5 +1,7 @@
 FROM //build/docker:dracon-base-go
 
+RUN apk add --update --no-cache jq
+
 COPY golang_gosec /parse
 
 ENTRYPOINT ["/parse"]


### PR DESCRIPTION
gosec supports a configuration file, but the range of settings that can be configured within it is limited; in particular, it lacks equivalents for the `-include`, `-exclude` and `-exclude-dir` command line options. Add jq to the gosec producer container, so that values for these options can be specified in the configuration file and transformed into real command line options by the Dracon producer.