### PR TITLE
Revert "Add jq to gosec producer container (#61)"

### DIFF
--- a/producers/golang_gosec/Dockerfile
+++ b/producers/golang_gosec/Dockerfile
@@ -1,7 +1,5 @@
 FROM //build/docker:dracon-base-go
 
-RUN apk add --update --no-cache jq
-
 COPY golang_gosec /parse
 
 ENTRYPOINT ["/parse"]


### PR DESCRIPTION
gosec itself doesn't run in this container, so there's no use in jq being available in this container after all (since the intended purpose of it was to extract fields from gosec's JSON-based configuration file and transform them into gosec command line options).

This reverts commit 10d7faf536fda6d47e26bc4cb41d1997a0d39715.