### PR TITLE
Make releasing friendlier and less noisy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish
 on:
   push:
-    branches:
-      - master
     tags:
       - 'v*'
 jobs:

--- a/docs/contributers/RELEASES.md
+++ b/docs/contributers/RELEASES.md
@@ -19,10 +19,5 @@ This lets us use `git desribe` to give us a descriptive version from any commit 
 
 ## Creating a Release
 
-1. Tag the commit you would like to release from `master` and push the tags. This will trigger a GitHub workflow that creates a pre-release and pushes Docker images:
-   ```
-   git fetch --tags
-   git tag --annotate <version> --message "<version>"
-   git push origin --tags
-   ```
+1. Run `./pleasew run //scripts:tag-release` and follow the instructions. This will trigger a GitHub workflow that creates a pre-release with all the artifacts.
 2. Once satisfied, promote the new pre-release to a release.

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+git fetch origin master --tags &> /dev/null
+commit_sha=$(git rev-parse origin/master)
+
+highest_tag=$(git tag | sort | tail -n1)
+
+major=$(echo "${highest_tag}" | cut -f1 -d. | tr -dc '0-9')
+minor=$(echo "${highest_tag}" | cut -f2 -d. | tr -dc '0-9')
+patch=$(echo "${highest_tag}" | cut -f3 -d. | tr -dc '0-9')
+
+printf "> The highest current tag is '%s' (major: %d, minor: %d, patch: %d)\n" "${highest_tag}" "${major}" "${minor}" "${patch}"
+printf "> What kind of release is this? (For guidance, see: https://semver.org/) [major/minor/patch] " 
+read release_type
+case "${release_type}" in
+major)
+    major=$((major+1))
+    minor=0
+    patch=0
+    ;;
+minor)
+    minor=$((minor+1))
+    patch=0
+    ;;
+patch)
+    patch=$((patch+1))
+    ;;
+*)
+  printf "!> Invalid option: '%s'.\n" "${release_type}"
+  exit 1
+  ;;
+esac
+
+new_tag="v${major}.${minor}.${patch}"
+
+printf "> The new release will be '%s'. Is this OK? [y/N] " "${new_tag}"
+read ok
+if [ "${ok}" != "y" ]; then
+    printf "Not OK, exiting.\n"
+fi
+
+git tag --annotate "${new_tag}" --message "${new_tag}" "${commit_sha}"
+git push origin --tags


### PR DESCRIPTION
This PR:
 * adds a script to help make releases a lot easier to perform (run a script and follow the instructions).
 * it also removes the creation of releases on every push to master as they can get quite noisy very quickly.