### PR TITLE
unbork alpine containers

### DIFF
--- a/build/docker/Dockerfile-base-go
+++ b/build/docker/Dockerfile-base-go
@@ -1,6 +1,6 @@
 FROM alpine:3.10 as alpine
 
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates libc6-compat
 
 ENTRYPOINT []
 


### PR DESCRIPTION
unbork alpine containers. Since we started building with github actions, the /produce and /consume binaries couldn't be ran because we build against glibc and we run in alpine which uses musl. The easiest fix is to add the glibc compatibility layer in our base golang container.