### PR TITLE
dropped the ref check from the enricher

### DIFF
--- a/pkg/enrichment/BUILD
+++ b/pkg/enrichment/BUILD
@@ -10,3 +10,18 @@ go_library(
         "//third_party/go:protobuf",
     ],
 )
+
+go_test(
+    name = "enrichment_test",
+    srcs = [
+        "issue.go",
+        "issue_test.go"
+    ],
+    deps = [
+        "//api/proto:v1",
+        "//third_party/go:stretchr_testify",
+        "//pkg/enrichment/db",
+        "//api/proto:v1",
+        "//third_party/go:protobuf",
+    ],
+)

--- a/pkg/enrichment/db/BUILD
+++ b/pkg/enrichment/db/BUILD
@@ -6,7 +6,7 @@ go_library(
     ],
     visibility = [
         "//cmd/enricher",
-        "//pkg/enrichment",
+        "//pkg/enrichment/...",
     ],
     deps = [
         "//pkg/enrichment/db/migrations",

--- a/pkg/enrichment/issue.go
+++ b/pkg/enrichment/issue.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strings"
 
 	v1 "github.com/thought-machine/dracon/api/proto/v1"
 
@@ -18,10 +19,12 @@ import (
 // GetHash returns the hash of an issue
 func GetHash(i *v1.Issue) string {
 	h := md5.New()
+	sourceNoRef := strings.Split(i.GetSource(), "?ref=")
+
 	io.WriteString(h, i.GetTarget())
 	io.WriteString(h, i.GetType())
 	io.WriteString(h, i.GetTitle())
-	io.WriteString(h, i.GetSource())
+	io.WriteString(h, sourceNoRef[0])
 	io.WriteString(h, i.GetSeverity().String())
 	io.WriteString(h, fmt.Sprintf("%f", i.GetCvss()))
 	io.WriteString(h, i.GetConfidence().String())

--- a/pkg/enrichment/issue_test.go
+++ b/pkg/enrichment/issue_test.go
@@ -1,0 +1,34 @@
+package enrichment
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHash(t *testing.T) {
+	expectedIssues := &v1.Issue{
+		Target:     "pkg:golang/github.com/coreos/etcd@0.5.0-alpha.5",
+		Type:       "Vulnerable Dependency",
+		Title:      "[CVE-2018-1099]  Improper Input Validation",
+		Source:     "git.foo.com/repo.git?ref=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Severity:   v1.Severity_SEVERITY_MEDIUM,
+		Cvss:       5.5,
+		Confidence: v1.Confidence_CONFIDENCE_HIGH,
+		Description: fmt.Sprintf("CVSS Score: %v\nCvssVector: %s\nCve: %s\nCwe: %s\nReference: %s\n",
+			"5.5", "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N", "CVE-2018-1099",
+			"", "https://ossindex.sonatype.org/vuln/8a190129-526c-4ee0-b663-92f38139c165"),
+	}
+	assert.Equal(t, GetHash(expectedIssues), "ccc217a4c2fd348bc5c6c4d73ad4311a")
+
+	expectedIssues.Source = strings.NewReplacer("aa", "bc").Replace(expectedIssues.Source)
+	// Test for regression on Bug where we would calculate ?ref=<> value for enrichment
+	assert.Equal(t, GetHash(expectedIssues), "ccc217a4c2fd348bc5c6c4d73ad4311a")
+
+	expectedIssues.Source = strings.NewReplacer("git.foo.com/repo.git", "https://example.com/foo/bar").Replace(expectedIssues.Source)
+	assert.NotEqual(t, GetHash(expectedIssues), "3c73dcc2f7c647a4ff460249074a8d50")
+}


### PR DESCRIPTION
The enricher so far was assuming that an issue found across 2 different commits counts as a regression (was taking into account the source git repo reference when calculating finding unique hashes)

Since 1 commit is unrealistically short period for orgs with a monorepo, this pr drops the ?ref=<val> part of the "source" field when it calculates the hash.

WARNING: this means that Dracon currently cannot process regressions, once it finds something on a repository it will always be marked as a duplicate, fgurther work is needed to address this