### PR TITLE
Add elasticsearch_filebeat producer

### DIFF
--- a/producers/elasticsearch_filebeat/BUILD
+++ b/producers/elasticsearch_filebeat/BUILD
@@ -1,0 +1,36 @@
+subinclude("@third_party/subrepos/pleasings//docker")
+
+go_binary(
+    name = "elasticsearch_filebeat",
+    srcs = [
+        "main.go",
+    ],
+    deps = [
+        "//api/proto:v1",
+        "//producers",
+        "//producers/elasticsearch_filebeat/types:elasticsearch-filebeat-issue",
+    ],
+)
+
+go_test(
+    name = "elasticsearch_filebeat_test",
+    srcs = [
+        "main.go",
+        "main_test.go",
+    ],
+    deps = [
+        "//api/proto:v1",
+        "//producers",
+        "//producers/elasticsearch_filebeat/types:elasticsearch-filebeat-issue",
+        "//third_party/go:stretchr_testify",
+    ],
+)
+
+docker_image(
+    name = "dracon-producer-elasticsearchfilebeat",
+    srcs = [
+        ":elasticsearch_filebeat",
+    ],
+    base_image = "//build/docker:dracon-base-go",
+    image = "dracon-producer-elasticsearch-filebeat",
+)

--- a/producers/elasticsearch_filebeat/Dockerfile
+++ b/producers/elasticsearch_filebeat/Dockerfile
@@ -1,0 +1,5 @@
+FROM //build/docker:dracon-base-go
+
+COPY elasticsearch_filebeat /elasticsearch_filebeat
+
+ENTRYPOINT ["/elasticsearch_filebeat"]

--- a/producers/elasticsearch_filebeat/main.go
+++ b/producers/elasticsearch_filebeat/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
+	types "github.com/thought-machine/dracon/producers/elasticsearch_filebeat/types/elasticsearch-filebeat-issue"
+
+	"github.com/thought-machine/dracon/producers"
+)
+
+func main() {
+	if err := producers.ParseFlags(); err != nil {
+		log.Fatal(err)
+	}
+	var results types.ElasticSearchFilebeatResult
+	if err := producers.ParseInFileJSON(&results); err != nil {
+		log.Fatal(err)
+	}
+
+	issues := parseIssues(&results)
+	if err := producers.WriteDraconOut(
+		"elasticsearch-filebeat",
+		issues,
+	); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func parseIssues(results *types.ElasticSearchFilebeatResult) []*v1.Issue {
+	issues := []*v1.Issue{}
+
+	for _, h := range results.Hits.Hits {
+
+		issues = append(issues, &v1.Issue{
+			Target:      fmt.Sprintf("%s (%s)", h.Source.Host.Name, h.Source.Host.ID),
+			Type:        "Antivirus Issue",
+			Title:       fmt.Sprintf("Antivirus Issue on %s", h.Source.Host.Name),
+			Severity:    v1.Severity_SEVERITY_INFO,
+			Cvss:        0.0,
+			Confidence:  v1.Confidence_CONFIDENCE_MEDIUM,
+			Description: h.Source.Message,
+		})
+
+	}
+	return issues
+}

--- a/producers/elasticsearch_filebeat/main_test.go
+++ b/producers/elasticsearch_filebeat/main_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
+	types "github.com/thought-machine/dracon/producers/elasticsearch_filebeat/types/elasticsearch-filebeat-issue"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseIssues(t *testing.T) {
+	var results types.ElasticSearchFilebeatResult
+	json.Unmarshal([]byte(exampleOutput), &results)
+
+	issues := parseIssues(&results)
+	expectedIssue := &v1.Issue{
+		Target:      "foo-01234.example.com (5636DD9E-761B-41AB-8B40-BDDD8626988D)",
+		Type:        "Antivirus Issue",
+		Title:       "Antivirus Issue on foo-01234.example.com",
+		Severity:    v1.Severity_SEVERITY_INFO,
+		Cvss:        0.0,
+		Confidence:  v1.Confidence_CONFIDENCE_MEDIUM,
+		Description: "error[013a0f06]: ESET Daemon: Error updating Antivirus modules: Server not found.",
+	}
+
+	assert.Equal(t, issues[0].Target, expectedIssue.Target)
+	assert.Equal(t, issues[0].Type, expectedIssue.Type)
+	assert.Equal(t, issues[0].Title, expectedIssue.Title)
+	assert.Equal(t, issues[0].Severity, expectedIssue.Severity)
+	assert.Equal(t, issues[0].Cvss, expectedIssue.Cvss)
+	assert.Equal(t, issues[0].Confidence, expectedIssue.Confidence)
+	assert.Equal(t, issues[0].Description, expectedIssue.Description)
+}
+
+var exampleOutput = `{
+	"took": 187,
+	"timed_out": false,
+	"_shards": {
+	  "total": 45,
+	  "successful": 45,
+	  "skipped": 40,
+	  "failed": 0
+	},
+	"hits": {
+	  "total": 1,
+	  "max_score": null,
+	  "hits": [
+		{
+		  "_index": "filebeat-7.6.0-2020.11.24",
+		  "_type": "_doc",
+		  "_id": "MjGs1VOXARhKg6Ac5tQM",
+		  "_version": 1,
+		  "_score": null,
+		  "_source": {
+			"agent": {
+			  "hostname": "foo-01234.example.com",
+			  "id": "0fabad50-a690-4193-8714-370b523d2b04",
+			  "type": "filebeat",
+			  "ephemeral_id": "f9290b4a-3500-4a55-a870-0d5611f04e53",
+			  "version": "7.6.0"
+			},
+			"process": {
+			  "name": "esets",
+			  "pid": 314
+			},
+			"log": {
+			  "file": {
+				"path": "/var/log/system.log"
+			  },
+			  "offset": 186662
+			},
+			"fileset": {
+			  "name": "syslog"
+			},
+			"message": "error[013a0f06]: ESET Daemon: Error updating Antivirus modules: Server not found.",
+			"tags": [
+			  "testENV",
+			  "tls",
+			  "v1.0",
+			  "clientcert",
+			  "beats_input_codec_plain_applied"
+			],
+			"input": {
+			  "type": "log"
+			},
+			"@timestamp": "2020-11-24T06:52:07.000Z",
+			"system": {
+			  "syslog": {}
+			},
+			"ecs": {
+			  "version": "1.4.0"
+			},
+			"service": {
+			  "type": "system"
+			},
+			"host": {
+			  "hostname": "foo-01234",
+			  "os": {
+				"build": "19H15",
+				"kernel": "19.6.0",
+				"name": "Mac OS X",
+				"family": "darwin",
+				"version": "10.15.7",
+				"platform": "darwin"
+			  },
+			  "name": "foo-01234.example.com",
+			  "id": "5636DD9E-761B-41AB-8B40-BDDD8626988D",
+			  "architecture": "x86_64"
+			},
+			"@version": "1",
+			"event": {
+			  "timezone": "+00:00",
+			  "module": "system",
+			  "dataset": "system.syslog"
+			}
+		  },
+		  "fields": {
+			"@timestamp": [
+			  "2020-11-24T06:52:07.000Z"
+			]
+		  },
+		  "sort": [
+			1606200727000
+		  ]
+		}
+	  ]
+	},
+	"aggregations": {
+	  "2": {
+		"buckets": [
+		  {
+			"key_as_string": "2020-11-24T06:00:00.000Z",
+			"key": 1606197600000,
+			"doc_count": 1
+		  }
+		]
+	  }
+	}
+  }
+`

--- a/producers/elasticsearch_filebeat/types/BUILD
+++ b/producers/elasticsearch_filebeat/types/BUILD
@@ -1,0 +1,7 @@
+go_library(
+    name = "elasticsearch-filebeat-issue",
+    srcs = [
+        "elasticsearch-filebeat-issue.go",
+    ],
+    visibility = ["//producers/elasticsearch_filebeat/..."]
+)

--- a/producers/elasticsearch_filebeat/types/elasticsearch-filebeat-issue.go
+++ b/producers/elasticsearch_filebeat/types/elasticsearch-filebeat-issue.go
@@ -1,0 +1,25 @@
+package types
+
+type ElasticSearchFilebeatResult struct {
+	Hits ElasticSearchFilebeatHits `json:"hits"`
+}
+
+type ElasticSearchFilebeatHits struct {
+	Hits []ElasticSearchFilebeatHit `json:"hits"`
+}
+
+type ElasticSearchFilebeatHit struct {
+	ID        string                      `json:"_id"`
+	Source    ElasticSearchFilebeatSource `json:"_source"`
+}
+
+type ElasticSearchFilebeatSource struct {
+	Message   string                    `json:"message"`
+	Timestamp string                    `json:"@timestamp"`
+	Host      ElasticSearchFilebeatHost `json:"host"`
+}
+
+type ElasticSearchFilebeatHost struct {
+	Name         string `json:"name"`
+	ID           string `json:"id"`
+}


### PR DESCRIPTION
Tested with:

```
# Build producer
plz build //producers/elasticsearch_filebeat:elasticsearch_filebeat

# Run test
plz test //producers/elasticsearch_filebeat:elasticsearch_filebeat_test

# Build docker image
plz build //producers/elasticsearch_filebeat:dracon-producer-elasticsearchfilebeat
plz-out/bin/producers/elasticsearch_filebeat/dracon-producer-elasticsearchfilebeat.sh

# Export ES data to /tmp/elastic-out.json
# ...

# Run docker container with elastic input
cd /tmp
docker run -v $(pwd):/code/ --rm -it thoughtmachine/dracon-producer-elasticsearch-filebeat -in /code/elastic-out.json -out /code/dracon-out.pb 
```