### PR TITLE
Add -append option to producers

### DIFF
--- a/pkg/putil/write.go
+++ b/pkg/putil/write.go
@@ -79,3 +79,30 @@ func WriteResults(
 	log.Printf("wrote %d issues from to %s", len(issues), outFile)
 	return nil
 }
+
+// AppendResults appends the given issues to the existing output file
+func AppendResults(issues []*v1.Issue, outFile string) error {
+	outBytes, err := ioutil.ReadFile(outFile)
+	if err != nil {
+		return fmt.Errorf("could not read file '%s': %w", outFile, err)
+	}
+
+	out := v1.LaunchToolResponse{}
+	if err := proto.Unmarshal(outBytes, &out); err != nil {
+		return fmt.Errorf("could not unmarshal contents of file '%s': %s", outFile, err)
+	}
+
+	out.Issues = append(out.Issues, issues...)
+
+	outBytes, err = proto.Marshal(&out)
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(outFile, outBytes, 0644); err != nil {
+		return fmt.Errorf("could not write to file '%s': %w", outFile, err)
+	}
+
+	log.Printf("appended %d issues (now %d) to %s", len(issues), len(out.Issues), outFile)
+	return nil
+}

--- a/producers/producer.go
+++ b/producers/producer.go
@@ -22,6 +22,7 @@ import (
 var (
 	InResults string
 	OutFile   string
+	Append    bool
 )
 
 const (
@@ -36,6 +37,7 @@ const (
 func init() {
 	flag.StringVar(&InResults, "in", "", "")
 	flag.StringVar(&OutFile, "out", "", "")
+	flag.BoolVar(&Append, "append", false, "Append to output file instead of overwriting it")
 }
 
 // ParseFlags will parse the input flags for the producer and perform simple validation
@@ -87,7 +89,13 @@ func WriteDraconOut(
 		scanStartTime = time.Now().UTC().Format(time.RFC3339)
 	}
 	scanUUUID := os.Getenv(EnvDraconScanID)
-	return putil.WriteResults(toolName, cleanIssues, OutFile, scanUUUID, scanStartTime)
+
+	stat, err := os.Stat(OutFile)
+	if Append && err == nil && stat.Size() > 0 {
+		return putil.AppendResults(cleanIssues, OutFile)
+	} else {
+		return putil.WriteResults(toolName, cleanIssues, OutFile, scanUUUID, scanStartTime)
+	}
 }
 
 func getSource() string {

--- a/producers/producer_test.go
+++ b/producers/producer_test.go
@@ -1,6 +1,7 @@
 package producers
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -35,12 +36,16 @@ func TestParseInFileJSON(t *testing.T) {
 func TestWriteDraconOut(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "dracon-test")
 	assert.Nil(t, err)
+	defer os.Remove(tmpFile.Name())
+
 	baseTime := time.Now().UTC()
 	timestamp := baseTime.Format(time.RFC3339)
 	os.Setenv(EnvDraconStartTime, timestamp)
 	os.Setenv(EnvDraconScanID, "ab3d3290-cd9f-482c-97dc-ec48bdfcc4de")
-	defer os.Remove(tmpFile.Name())
+
 	OutFile = tmpFile.Name()
+	Append = false
+
 	err = WriteDraconOut(
 		"dracon-test",
 		[]*v1.Issue{
@@ -64,4 +69,48 @@ func TestWriteDraconOut(t *testing.T) {
 	assert.Equal(t, "./example.yaml", res.GetIssues()[0].GetDescription())
 	assert.Equal(t, baseTime.Unix(), res.GetScanInfo().GetScanStartTime().GetSeconds())
 	assert.Equal(t, "ab3d3290-cd9f-482c-97dc-ec48bdfcc4de", res.GetScanInfo().GetScanUuid())
+}
+
+func TestWriteDraconOutAppend(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "dracon-test")
+	assert.Nil(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	baseTime := time.Now().UTC()
+	timestamp := baseTime.Format(time.RFC3339)
+	os.Setenv(EnvDraconStartTime, timestamp)
+	os.Setenv(EnvDraconScanID, "ab3d3290-cd9f-482c-97dc-ec48bdfcc4de")
+
+	OutFile = tmpFile.Name()
+	Append = true
+
+	for _, i := range []int{0, 1, 2} {
+		err = WriteDraconOut(
+			"dracon-test",
+			[]*v1.Issue{
+				&v1.Issue{
+					Target:      fmt.Sprintf("target%d", i),
+					Title:       fmt.Sprintf("title%d", i),
+					Description: fmt.Sprintf("desc%d", i),
+				},
+			},
+		)
+		assert.Nil(t, err)
+	}
+
+	pBytes, err := ioutil.ReadFile(tmpFile.Name())
+	res := v1.LaunchToolResponse{}
+	err = proto.Unmarshal(pBytes, &res)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "dracon-test", res.GetToolName())
+	assert.Equal(t, baseTime.Unix(), res.GetScanInfo().GetScanStartTime().GetSeconds())
+	assert.Equal(t, "ab3d3290-cd9f-482c-97dc-ec48bdfcc4de", res.GetScanInfo().GetScanUuid())
+	assert.Equal(t, 3, len(res.GetIssues()))
+
+	for _, i := range []int{0, 1, 2} {
+		assert.Equal(t, fmt.Sprintf("target%d", i), res.GetIssues()[i].GetTarget())
+		assert.Equal(t, fmt.Sprintf("title%d", i), res.GetIssues()[i].GetTitle())
+		assert.Equal(t, fmt.Sprintf("desc%d", i), res.GetIssues()[i].GetDescription())
+	}
 }


### PR DESCRIPTION
To support incremental writing of producer output files, add support for an `-append` option to the common producer library. When specified on the command line, this appends issues from the file given by `-in` to the list of issues in the protobuf stored in `-out` if `-out` already exists and is non-empty, rather than overwriting the existing file entirely.