### PR TITLE
tag-release.sh: use Git's built-in logic to sort tags

### DIFF
--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 git fetch origin master --tags &> /dev/null
 commit_sha=$(git rev-parse origin/master)
 
-highest_tag=$(git tag | sort | tail -n1)
+highest_tag="$(git tag -l --sort=-v:refname | grep ^v | sed 1q)"
 
 major=$(echo "${highest_tag}" | cut -f1 -d. | tr -dc '0-9')
 minor=$(echo "${highest_tag}" | cut -f2 -d. | tr -dc '0-9')


### PR DESCRIPTION
`git tag | sort` can't reliably identify the tag with the highest version number because it sorts lexicographically, so (for example) v1.10.0 is considered less recent than v0.9.0. Instead, use `git tag`'s built-in logic for sorting tags.

Closes #82.