### PR TITLE
support direct value jira fields

### DIFF
--- a/common/jira/config.yaml
+++ b/common/jira/config.yaml
@@ -14,21 +14,30 @@ defaultValues:
     # - id: 'customfield_10050'
     #   fieldType: single-value
     #   values: ['Foo']
+    #  translates to jira api as "customfield_10050":{"value":"foo"}
 
     ## This example will fill in the customfield_10050, a multi-value field, with the value 'Foo' and 'Bar'
     # - id: 'customfield_10050'
     #   fieldType: multi-value
     #   values: ['Foo', 'Bar']
 
-    ## This example will fill in the customfield_10050, a float value field, with the number 55.3  
+    ## This example will fill in the customfield_10050, a float value field, with the number 55.3
     # - id: 'customfield_10050'
     #   fieldType: float
     #   values: ['55.3']   # Note, this is still specified as a string input
 
-## More explanation on fieldTypes:
+    ## This example will fill in the customfield_10050, a "simple" value field, with the number 55.3
+    # - id: 'customfield_10050'
+    #   fieldType: simple-value
+    #   values: ['Foo']
+    # this translates to jira api as "customfield_10050": "foo"
+
+    ## More explanation on fieldTypes:
 ## single-value: can only be populated by one value  (e.g. Project Key)
 ## multi-value: can be populated by multiple values  (e.g. Components)
 ## float: can be populated by only one numeric value (e.g. CVSS)
+## simple-value: will translate to the special jira use case of "customfield_id":"value"
+## simple-value is provided as a workaround when single-value does not work with your jira setup
 
 ## Uncomment the fields you want included in the Issue's Description
 addToDescription:

--- a/common/jira/config.yaml
+++ b/common/jira/config.yaml
@@ -14,7 +14,7 @@ defaultValues:
     # - id: 'customfield_10050'
     #   fieldType: single-value
     #   values: ['Foo']
-    #  translates to jira api as "customfield_10050":{"value":"foo"}
+    #  translates to jira api as "customfield_10050":{"value":"Foo"}
 
     ## This example will fill in the customfield_10050, a multi-value field, with the value 'Foo' and 'Bar'
     # - id: 'customfield_10050'
@@ -26,11 +26,11 @@ defaultValues:
     #   fieldType: float
     #   values: ['55.3']   # Note, this is still specified as a string input
 
-    ## This example will fill in the customfield_10050, a "simple" value field, with the number 55.3
+    ## This example will fill in the customfield_10050, a "simple" value field, with the value 'Foo'
     # - id: 'customfield_10050'
     #   fieldType: simple-value
     #   values: ['Foo']
-    # this translates to jira api as "customfield_10050": "foo"
+    # this translates to jira api as "customfield_10050": "Foo"
 
     ## More explanation on fieldTypes:
 ## single-value: can only be populated by one value  (e.g. Project Key)

--- a/common/jira/jira/apiutils.go
+++ b/common/jira/jira/apiutils.go
@@ -76,6 +76,8 @@ func makeCustomField(fieldType string, values []string) interface{} {
 		} else {
 			log.Fatalf("Error parsing float field-type: %v", err)
 		}
+	case "simple-value":
+	return values[0]
 	default:
 		log.Printf("Warning: Field type %s is not supported. Edit your config.yaml file, as this field will not be displayed correctly.", fieldType)
 		return nil

--- a/common/jira/jira/apiutils.go
+++ b/common/jira/jira/apiutils.go
@@ -77,7 +77,7 @@ func makeCustomField(fieldType string, values []string) interface{} {
 			log.Fatalf("Error parsing float field-type: %v", err)
 		}
 	case "simple-value":
-	return values[0]
+	    return values[0]
 	default:
 		log.Printf("Warning: Field type %s is not supported. Edit your config.yaml file, as this field will not be displayed correctly.", fieldType)
 		return nil

--- a/common/jira/jira/apiutils_test.go
+++ b/common/jira/jira/apiutils_test.go
@@ -50,9 +50,13 @@ func TestMakeCustomField(t *testing.T) {
 	res3 := makeCustomField("float", []string{"4.22"})
 	exp3 := 4.22
 
+	res4 := makeCustomField("simple-value",[]string{"test-value"})
+	exp4 := "test-value"
+
 	assert.EqualValues(t, res1, exp1)
 	assert.EqualValues(t, res2, exp2)
 	assert.Equal(t, res3, exp3)
+	assert.Equal(t, res4, exp4)
 }
 
 func TestMakeDescription(t *testing.T) {


### PR DESCRIPTION
we had a bug were the jira consumer would fail with "Operation value must be a string" when updating a specific customfield. Turns out jira supports two types of single value fields
```
  "customfield_15801" :
        {"value" : "Test"}
    }

```
and 
` "customfield_15801": "TEST"`
source:
https://community.atlassian.com/t5/Jira-questions/JIRA-REST-API-calls-failing-with-quot-Operation-value-must-be-a/qaq-p/755656


updating the jira consumer to recognise this use case