### PR TITLE
Fix issue with alpine images.

### DIFF
--- a/resources/patches/patch-dracon.PipelineRun.yaml
+++ b/resources/patches/patch-dracon.PipelineRun.yaml
@@ -35,3 +35,16 @@
   path: /spec/resources/-
   value: {name: {{$e.Name}}, resourceRef: {name: "{{$runID}}-{{$e.Name}}"}}
 {{end}}
+
+# Set ndots to 1 for Alpine images to avoid DNS resolution failures see:
+#
+# https://github.com/kubernetes/kubernetes/issues/64924#issuecomment-488848061
+# https://github.com/gliderlabs/docker-alpine/issues/8#issuecomment-504222376
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/9017
+#
+# Relative domain names with more than one component (e.g. example.com) will not be subject to the search path and
+# resolve to the absolute domain name (e.g. example.com.) at the cost of breaking relative service domain names (e.g.
+# service.namespace) meant to resolve to the full cluster address (e.g. service.namespace.svc.cluster.local.).
+- op: add
+  path: /spec/podTemplate/dnsConfig/options/-
+  value: {name: ndots, value: "1"}


### PR DESCRIPTION
Alpine images use the [musl dns client which will stop further searching when a DNS server for the domains in the search domain returns anything other than an NXDOMAIN](https://gitlab.alpinelinux.org/alpine/aports/-/issues/9017) (e.g. a SERVFAIL). Unfortunately DNS servers not adhering to the spec are rife causing domain resolution to break. As the container's /etc/resolv.conf search domain is set by default by k8s to include the values from the host server's /etc/resolv.conf, this is particularly likely to occur with microk8s, where a user's search domain may have been set to include an internal domain.

The commit works around this issue by setting ndots (the number of dots a domain has to have before an absolute query is made) back to the default of 1. This means that relative domain names with more than one component (e.g. example.com) will not be subject to the search path and resolve to the absolute domain name (e.g. example.com.) at the cost of breaking relative service domain names (e.g. service.namespace) meant to resolve to the full cluster address (e.g. service.namespace.svc.cluster.local.).