### PR TITLE
Remove confusing release instructions

### DIFF
--- a/docs/contributers/RELEASES.md
+++ b/docs/contributers/RELEASES.md
@@ -2,21 +2,6 @@
 
 Dracon releases follow [Semantic Versioning](https://semver.org/)
 
-We use annotated git tags to define a release by doing the following:
-
-```
-$ git tag --annotate <version>
-e.g:
-# git tag --annotate v0.1.0
-# then push the tags
-$ git push --tags
-```
-
-This lets us use `git desribe` to give us a descriptive version from any commit in the format `<version>-<commits since version>-<short-sha>`, e.g.:
-
-- `v0.0.0` (when on the annotated commit (`git checkout v0.0.0`))
-- `v0.0.0-3-g7487887`
-
 ## Creating a Release
 
 1. Run `./pleasew run //scripts:tag-release` and follow the instructions. This will trigger a GitHub workflow that creates a pre-release with all the artifacts.


### PR DESCRIPTION
The release instructions are much simpler than pushing our own tags etc. So i've removed the explanation. We could probably re-add this in a much less prominent place if we wanted to explain it in the future.