### PR TITLE
Use local images in development

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -11,6 +11,7 @@ version = 15.17.1
 [buildconfig]
 default-docker-repo = index.docker.io/thoughtmachine
 protoc-deps = //third_party/proto:protoc_deps
+kustomize-tool = //third_party/tools:kustomize
 
 [go]
 importpath = github.com/thought-machine/dracon
@@ -33,6 +34,5 @@ positionallabels = true
 flag = --context
 
 [alias "dracon"]
-cmd = run //cmd/dracon --
-flag = --context
+cmd = run //scripts/development/kind:dracon --
 flag = --pipeline

--- a/build/defs/BUILD
+++ b/build/defs/BUILD
@@ -1,0 +1,6 @@
+for build_def in glob(["**.build_defs"]):
+    export_file(
+        name = basename(build_def).split(".")[0],
+        src = build_def,
+        visibility = ["PUBLIC"],
+    )

--- a/build/defs/kustomize.build_defs
+++ b/build/defs/kustomize.build_defs
@@ -1,0 +1,109 @@
+"""Build rules for working with Kustomize (https://kustomize.io)
+"""
+
+def kustomized_config(
+    name: str,
+    srcs: list = [],
+    images: list = [],
+    visibility: list = [],
+    kube_score_ignored_tests: list = [],
+):
+    """Build rule for building Kustomize projects.
+
+    Args:
+        name: The name of the build rule.
+        srcs: The source kustomize resources including the kustomization.yaml
+        images: The docker images that the resources use that will be replaced with development references.
+        visibility: The targets to make the kustomized configuration visible to.
+        kube_score_ignored_tests: The kube_score tests to skip.
+    """
+    replace_images_rule=_replace_images_cmd(name, images)
+    replace_srcs_rule=_replace_srcs_cmd(name, srcs)
+
+    kustomized_rule=genrule(
+        name = name,
+        srcs = srcs,
+        outs = [f"{name}_kustomized.yaml"],
+        cmd = f"""
+set -euo pipefail
+cp $PKG/* .
+kustomization_file="kustomization.yaml"
+if [ ! -f "${kustomization_file}" ]; then
+    echo "missing kustomization file in $PKG"
+    exit 1
+fi
+$(exe {replace_images_rule})
+$(exe {replace_srcs_rule})
+$(exe {CONFIG.KUSTOMIZE_TOOL}) build . > $HOME/$OUTS
+        """,
+        tools = [
+            CONFIG.KUSTOMIZE_TOOL,
+            replace_images_rule,
+            replace_srcs_rule,
+        ],
+        visibility = visibility,
+    )
+
+    _kube_score(name, kustomized_rule, kube_score_ignored_tests)
+
+    return kustomized_rule
+
+def _replace_images_cmd(name: str, images: list):
+    return genrule(
+        name = f"{name}_replace_images",
+        srcs = [f"{image}_fqn" for image in images],
+        outs = [f"{name}_replace_images.sh"],
+        binary = True,
+        cmd = """
+set -euo pipefail
+echo '#!/bin/bash\nset -euo pipefail\n' > $OUTS
+for fqn_file in $SRCS; do
+    fqn=$(<$fqn_file)
+    repository=$(echo $fqn | cut -f1 -d\:)
+    cat <<EOF >> $OUTS
+
+if ! grep -r "${repository}"; then
+    echo "could not find any usage of ${repository}"
+    exit 1
+fi
+find . -type f -exec sed -i 's#${repository}.*#"${fqn}"#g' {} \;
+
+EOF
+
+done
+        """
+    )
+
+def _replace_srcs_cmd(name: str, srcs: list):
+    src_to_location_cmds=[f"find . -type f -exec sed -i 's#{target}#$(location {target})#g' {{}} +" for target in srcs]
+    return sh_cmd(
+        name = f"_{name}_replace_srcs",
+        srcs = srcs,
+        shell = "/bin/bash",
+        cmd = "set -euo pipefail;" + "\n".join(src_to_location_cmds)
+    )
+
+def _kube_score(
+    name: str, 
+    kustomized_rule: str,
+    kube_score_ignored_tests: list = [],
+):
+    if CONFIG.KUBE_SCORE_TOOL == "":
+        return
+    ignore_test_flags=[f"--ignore-test {test}" for test in kube_score_ignored_tests]
+    ignore_tests_bash=" ".join(ignore_test_flags)
+    return gentest(
+        name = f"{name}_kube_score",
+        data = {
+            "srcs": [kustomized_rule],
+            "tool": [CONFIG.KUBE_SCORE_TOOL],
+        },
+        test_cmd = f"""
+        $(exe {CONFIG.KUBE_SCORE_TOOL}) score {ignore_tests_bash} $DATA_SRCS
+        """,
+        test_tools = [CONFIG.KUBE_SCORE_TOOL],
+        no_test_output = True,
+    )
+
+CONFIG.setdefault('KUSTOMIZE_TOOL', 'kustomize')
+CONFIG.setdefault('KUBE_SCORE_TOOL', '')

--- a/build/docker/BUILD
+++ b/build/docker/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 # Can be used to build Dracon if you don't want to set up a build environment
 docker_image(

--- a/cmd/dracon/BUILD
+++ b/cmd/dracon/BUILD
@@ -12,4 +12,5 @@ go_binary(
         "//cmd/dracon/cmd",
         "//third_party/go:spf13_cobra",
     ],
+    visibility = ["//scripts/..."],
 )

--- a/cmd/enricher/BUILD
+++ b/cmd/enricher/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "enricher",
@@ -22,4 +22,5 @@ docker_image(
     srcs = [":enricher"],
     base_image = "//build/docker:dracon-base-go",
     image = "dracon-enricher",
+    visibility = ["//examples/..."],
 )

--- a/consumers/defectdojo_c/BUILD
+++ b/consumers/defectdojo_c/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 python_binary(
     name = "defectdojo",

--- a/consumers/elasticsearch_c/BUILD
+++ b/consumers/elasticsearch_c/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "elasticsearch_c",
@@ -37,4 +37,5 @@ docker_image(
     ],
     base_image = "//build/docker:dracon-base-go",
     image = "dracon-consumer-elasticsearch",
+    visibility = ["//examples/..."],
 )

--- a/consumers/jira_c/BUILD
+++ b/consumers/jira_c/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "jira_c",

--- a/consumers/slack/BUILD
+++ b/consumers/slack/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 
 go_binary(

--- a/consumers/stdout_json/BUILD
+++ b/consumers/stdout_json/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 python_binary(
     name = "stdout_json",

--- a/docs/designs/kustomize-support.md
+++ b/docs/designs/kustomize-support.md
@@ -1,0 +1,58 @@
+# Design: Kustomize Support and Motivation
+
+[Kustomize](https://kustomize.io/) is a highly popular tool for mutating/patching Kubernetes configuration files.
+
+## Local Development
+We can patch development parameters in transparently via plz. For example, `imagePullPolicy: Never` so that local clusters only use images that have been preloaded into the cluster.
+
+## WIP: Distribution
+
+_Note_: this section is WIP and subject to changes.
+
+End users should be able to use Kustomize to modify any of our example pipelines for their own use-cases. e.g.
+
+```yaml
+# ./kustomization.yaml
+resources:
+- github.com/thought-machine/dracon/examples/pipelines/golang-project?ref=v0.12.1
+# if the end-user is using plz, they can use a remote_file and reference the output directory instead
+
+namespace: dracon-demo
+commonLabels:
+    my-org.io/team: my-team
+
+patches:
+- path: patches/my-repository.yaml
+  target:
+    group: dracon
+    version: v1alpha1
+    kind: PipelineResource
+    name: "{{.RunID}}-git-github-oauth2-proxy"
+# note: this above patch doesn't currently read well so we may need to reconsider how we define pipelines.
+
+# ./patches/my-repository.yaml
+---
+apiVersion: dracon/v1alpha1
+kind: PipelineResource
+metadata:
+  name: "{{.RunID}}-git-github-oauth2-proxy"
+  labels: {}
+spec:
+  type: git
+  params:
+  - name: revision
+    value: master
+  - name: url
+    value: https://github.com/my-org/my-repository.git
+```
+
+running `kustomize build` will yield the kustomized configuration to stdout, which can be redirected to a file.
+
+e.g.
+
+```
+$ mkdir -p modified-golang-project/
+$ kustomize build > modified-golang-project/k8s_kustomized.yaml
+$ dracon setup --pipeline modified-golang-project
+$ dracon run --pipeline modified-golang-project
+```

--- a/examples/pipelines/golang-project/BUILD
+++ b/examples/pipelines/golang-project/BUILD
@@ -1,0 +1,20 @@
+subinclude("//build/defs:kustomize")
+
+kustomized_config(
+    name = "dev",
+    srcs = [
+        "elasticsearch-consumer.yaml",
+        "enricher.yaml",
+        "git-source.yaml",
+        "gosec-producer.yaml",
+        "kustomization.yaml",
+        "pipeline-run.yaml",
+        "pipeline.yaml",
+    ],
+    images = [
+        "//consumers/elasticsearch_c:dracon-consumer-elasticsearch",
+        "//cmd/enricher:dracon-enricher",
+        "//source/git:dracon-source-git",
+        "//producers/golang_gosec:dracon-producer-gosec",
+    ],
+)

--- a/examples/pipelines/golang-project/elasticsearch-consumer.yaml
+++ b/examples/pipelines/golang-project/elasticsearch-consumer.yaml
@@ -9,7 +9,7 @@ spec:
   steps:
   # run elasticsearch consumer
   - name: run-elasticsearch-consumer
-    image: thoughtmachine/dracon-consumer-elasticsearch:latest
+    image: index.docker.io/thoughtmachine/dracon-consumer-elasticsearch:latest
     env: [
       {name: ELASTICSEARCH_URL, value: http://elasticsearch.dracon.svc:9200}
     ]

--- a/examples/pipelines/golang-project/enricher.yaml
+++ b/examples/pipelines/golang-project/enricher.yaml
@@ -10,7 +10,7 @@ spec:
   steps:
   # run enricher
   - name: run-enricher
-    image: thoughtmachine/dracon-enricher:latest
+    image: index.docker.io/thoughtmachine/dracon-enricher:latest
     env:
     - name: ENRICHER_READ_PATH
       value: /workspace

--- a/examples/pipelines/golang-project/git-source.yaml
+++ b/examples/pipelines/golang-project/git-source.yaml
@@ -9,5 +9,5 @@ spec:
   outputs: {resources: [{name: source, type: storage}]}
   steps:
   - name: git-source
-    image: thoughtmachine/dracon-source-git:latest
+    image: index.docker.io/thoughtmachine/dracon-source-git:latest
     command: ["/git.sh"]

--- a/examples/pipelines/golang-project/gosec-producer.yaml
+++ b/examples/pipelines/golang-project/gosec-producer.yaml
@@ -20,7 +20,7 @@ spec:
     env: []
   # parse results
   - name: parse-gosec
-    image: thoughtmachine/dracon-producer-gosec:latest
+    image: index.docker.io/thoughtmachine/dracon-producer-gosec:latest
     command: ["/parse"]
     args: [
       "-in={{.ProducerToolOutPath}}",

--- a/examples/pipelines/golang-project/kustomization.yaml
+++ b/examples/pipelines/golang-project/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: dracon
+
+commonLabels:
+  app: dracon
+  app.kubernetes.io/component: "pipeline"
+  dracon.thoughtmachine.io/pipeline: "golang-project"
+
+resources:
+- elasticsearch-consumer.yaml
+- enricher.yaml
+- git-source.yaml
+- gosec-producer.yaml
+- pipeline-run.yaml
+- pipeline.yaml

--- a/examples/pipelines/mixed-lang-project/BUILD
+++ b/examples/pipelines/mixed-lang-project/BUILD
@@ -1,0 +1,24 @@
+subinclude("//build/defs:kustomize")
+
+kustomized_config(
+    name = "dev",
+    srcs = [
+        "elasticsearch-consumer.yaml",
+        "enricher.yaml",
+        "git-source.yaml",
+        "gosec-producer.yaml",
+        "spotbugs-producer.yaml",
+        "bandit-producer.yaml",
+        "kustomization.yaml",
+        "pipeline-run.yaml",
+        "pipeline.yaml",
+    ],
+    images = [
+        "//consumers/elasticsearch_c:dracon-consumer-elasticsearch",
+        "//cmd/enricher:dracon-enricher",
+        "//source/git:dracon-source-git",
+        "//producers/golang_gosec:dracon-producer-gosec",
+        "//producers/python_bandit:dracon-producer-bandit",
+        "//producers/java_spotbugs:dracon-producer-java_spotbugs",
+    ],
+)

--- a/examples/pipelines/mixed-lang-project/bandit-producer.yaml
+++ b/examples/pipelines/mixed-lang-project/bandit-producer.yaml
@@ -11,7 +11,7 @@ spec:
   steps:
   # run bandit
   - name: run-bandit
-    image: thoughtmachine/dracon-tool-bandit:latest
+    image: index.docker.io/thoughtmachine/dracon-tool-bandit:latest
     command: ["sh"]
     args: ["-c",
       "bandit --recursive {{.ProducerSourcePath}} --format json --output {{.ProducerToolOutPath}} || true"
@@ -20,7 +20,7 @@ spec:
     env: []
   # parse results
   - name: parse-bandit
-    image: thoughtmachine/dracon-producer-bandit:latest
+    image: index.docker.io/thoughtmachine/dracon-producer-bandit:latest
     command: ["/parse"]
     args: [
       "-in={{.ProducerToolOutPath}}",

--- a/examples/pipelines/mixed-lang-project/elasticsearch-consumer.yaml
+++ b/examples/pipelines/mixed-lang-project/elasticsearch-consumer.yaml
@@ -9,7 +9,7 @@ spec:
   steps:
   # run elasticsearch consumer
   - name: run-elasticsearch-consumer
-    image: thoughtmachine/dracon-consumer-elasticsearch:latest
+    image: index.docker.io/thoughtmachine/dracon-consumer-elasticsearch:latest
     env: [
       {name: ELASTICSEARCH_URL, value: http://elasticsearch.dracon.svc:9200}
     ]

--- a/examples/pipelines/mixed-lang-project/enricher.yaml
+++ b/examples/pipelines/mixed-lang-project/enricher.yaml
@@ -10,7 +10,7 @@ spec:
   steps:
   # run enricher
   - name: run-enricher
-    image: thoughtmachine/dracon-enricher:latest
+    image: index.docker.io/thoughtmachine/dracon-enricher:latest
     env:
     - name: ENRICHER_READ_PATH
       value: /workspace

--- a/examples/pipelines/mixed-lang-project/git-source.yaml
+++ b/examples/pipelines/mixed-lang-project/git-source.yaml
@@ -9,5 +9,5 @@ spec:
   outputs: {resources: [{name: source, type: storage}]}
   steps:
   - name: git-source
-    image: thoughtmachine/dracon-source-git:latest
+    image: index.docker.io/thoughtmachine/dracon-source-git:latest
     command: ["/git.sh"]

--- a/examples/pipelines/mixed-lang-project/gosec-producer.yaml
+++ b/examples/pipelines/mixed-lang-project/gosec-producer.yaml
@@ -20,7 +20,7 @@ spec:
     env: []
   # parse results
   - name: parse-gosec
-    image: thoughtmachine/dracon-producer-gosec:latest
+    image: index.docker.io/thoughtmachine/dracon-producer-gosec:latest
     imagePullPolicy: Never
     command: ["/parse"]
     args: [

--- a/examples/pipelines/mixed-lang-project/kustomization.yaml
+++ b/examples/pipelines/mixed-lang-project/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: dracon
+
+commonLabels:
+  app: dracon
+  app.kubernetes.io/component: "pipeline"
+  dracon.thoughtmachine.io/pipeline: "mixed-lang-project"
+
+resources:
+- elasticsearch-consumer.yaml
+- enricher.yaml
+- git-source.yaml
+- gosec-producer.yaml
+- bandit-producer.yaml
+- spotbugs-producer.yaml
+- pipeline-run.yaml
+- pipeline.yaml

--- a/examples/pipelines/mixed-lang-project/spotbugs-producer.yaml
+++ b/examples/pipelines/mixed-lang-project/spotbugs-producer.yaml
@@ -11,7 +11,7 @@ spec:
   steps:
   # run spotbugs
   - name: run-spotbugs
-    image: thoughtmachine/dracon-tool-spotbugs:latest
+    image: index.docker.io/thoughtmachine/dracon-tool-spotbugs:latest
     command: ["sh"]
     args: ["-c",
       "spotbugs {{.ProducerSourcePath}} -output {{.ProducerToolOutPath}} -xml:withMessages"
@@ -20,7 +20,7 @@ spec:
     env: []
   # parse results
   - name: parse-spotbugs
-    image: thoughtmachine/dracon-producer-spotbugs:latest
+    image: index.docker.io/thoughtmachine/dracon-producer-java_spotbugs:latest
     imagePullPolicy: Never
     command: ["/parse"]
     args: [

--- a/examples/pipelines/python-project/BUILD
+++ b/examples/pipelines/python-project/BUILD
@@ -1,0 +1,20 @@
+subinclude("//build/defs:kustomize")
+
+kustomized_config(
+    name = "dev",
+    srcs = [
+        "elasticsearch-consumer.yaml",
+        "enricher.yaml",
+        "git-source.yaml",
+        "bandit-producer.yaml",
+        "kustomization.yaml",
+        "pipeline-run.yaml",
+        "pipeline.yaml",
+    ],
+    images = [
+        "//consumers/elasticsearch_c:dracon-consumer-elasticsearch",
+        "//cmd/enricher:dracon-enricher",
+        "//source/git:dracon-source-git",
+        "//producers/python_bandit:dracon-producer-bandit",
+    ],
+)

--- a/examples/pipelines/python-project/bandit-producer.yaml
+++ b/examples/pipelines/python-project/bandit-producer.yaml
@@ -11,7 +11,7 @@ spec:
   steps:
   # run bandit
   - name: run-bandit
-    image: thoughtmachine/dracon-tool-bandit:latest
+    image: index.docker.io/thoughtmachine/dracon-tool-bandit:latest
     command: ["sh"]
     args: ["-c",
       "bandit --recursive {{.ProducerSourcePath}} --format json --output {{.ProducerToolOutPath}} || true"
@@ -20,7 +20,7 @@ spec:
     env: []
   # parse results
   - name: parse-bandit
-    image: thoughtmachine/dracon-producer-bandit:latest
+    image: index.docker.io/thoughtmachine/dracon-producer-bandit:latest
     command: ["/parse"]
     args: [
       "-in={{.ProducerToolOutPath}}",

--- a/examples/pipelines/python-project/elasticsearch-consumer.yaml
+++ b/examples/pipelines/python-project/elasticsearch-consumer.yaml
@@ -9,7 +9,7 @@ spec:
   steps:
   # run elasticsearch consumer
   - name: run-elasticsearch-consumer
-    image: thoughtmachine/dracon-consumer-elasticsearch:latest
+    image: index.docker.io/thoughtmachine/dracon-consumer-elasticsearch:latest
     imagePullPolicy: Never
     env: [
       {name: ELASTICSEARCH_URL, value: http://elasticsearch.dracon.svc:9200}

--- a/examples/pipelines/python-project/enricher.yaml
+++ b/examples/pipelines/python-project/enricher.yaml
@@ -10,7 +10,7 @@ spec:
   steps:
   # run enricher
   - name: run-enricher
-    image: thoughtmachine/dracon-enricher:latest
+    image: index.docker.io/thoughtmachine/dracon-enricher:latest
     imagePullPolicy: Never
     env:
     - name: ENRICHER_READ_PATH

--- a/examples/pipelines/python-project/git-source.yaml
+++ b/examples/pipelines/python-project/git-source.yaml
@@ -9,6 +9,6 @@ spec:
   outputs: {resources: [{name: source, type: storage}]}
   steps:
   - name: git-source
-    image: thoughtmachine/dracon-source-git:latest
+    image: index.docker.io/thoughtmachine/dracon-source-git:latest
     imagePullPolicy: Never
     command: ["/git.sh"]

--- a/examples/pipelines/python-project/kustomization.yaml
+++ b/examples/pipelines/python-project/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: dracon
+
+commonLabels:
+  app: dracon
+  app.kubernetes.io/component: "pipeline"
+  dracon.thoughtmachine.io/pipeline: "python-project"
+
+resources:
+- elasticsearch-consumer.yaml
+- enricher.yaml
+- git-source.yaml
+- bandit-producer.yaml
+- pipeline-run.yaml
+- pipeline.yaml

--- a/producers/dependency_check/BUILD
+++ b/producers/dependency_check/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "dependency_check",

--- a/producers/elasticsearch_filebeat/BUILD
+++ b/producers/elasticsearch_filebeat/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "elasticsearch_filebeat",

--- a/producers/golang_gosec/BUILD
+++ b/producers/golang_gosec/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "golang_gosec",
@@ -31,4 +31,5 @@ docker_image(
     ],
     base_image = "//build/docker:dracon-base-go",
     image = "dracon-producer-gosec",
+    visibility = ["//examples/..."],
 )

--- a/producers/golang_nancy/BUILD
+++ b/producers/golang_nancy/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 # this producer covers nancy https://github.com/sonatype-nexus-community/nancy
 

--- a/producers/java_spotbugs/BUILD
+++ b/producers/java_spotbugs/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "java_spotbugs",
@@ -31,4 +31,5 @@ docker_image(
     ],
     base_image = "//build/docker:dracon-base-go",
     image = "dracon-producer-java_spotbugs",
+    visibility = ["//examples/..."],
 )

--- a/producers/jira_producer/BUILD
+++ b/producers/jira_producer/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "sync_tickets",

--- a/producers/mobsf/BUILD
+++ b/producers/mobsf/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "entrypoint",

--- a/producers/npm_audit/BUILD
+++ b/producers/npm_audit/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "npm_audit",

--- a/producers/pipsafety/BUILD
+++ b/producers/pipsafety/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "pipsafety",

--- a/producers/python_bandit/BUILD
+++ b/producers/python_bandit/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "python_bandit",
@@ -25,4 +25,5 @@ docker_image(
     ],
     base_image = "//build/docker:dracon-base-go",
     image = "dracon-producer-bandit",
+    visibility = ["//examples/..."],
 )

--- a/producers/semgrep/BUILD
+++ b/producers/semgrep/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "semgrep",

--- a/producers/typescript_tslint/BUILD
+++ b/producers/typescript_tslint/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 go_binary(
     name = "typescript_tslint",

--- a/scripts/development/kind/BUILD
+++ b/scripts/development/kind/BUILD
@@ -53,7 +53,7 @@ sh_cmd(
     name = "deploy",
     srcs = ["deploy.sh"],
     cmd = """
-source "$(out_location //scripts/util)"
+source "$(out_location :_util)"
 source "$(out_location //third_party/sh:shflags)"
 
 ROOT_CERTIFICATES="$(out_location :_root_certificates)"
@@ -65,7 +65,7 @@ YQ_BIN="$(out_location //third_party/tools:yq)"
 source $SRCS
     """,
     data = [
-        "//scripts/util",
+        ":_util",
         "//third_party/tools:kind",
         "//third_party/sh:shflags",
         ":_root_certificates",
@@ -74,6 +74,39 @@ source $SRCS
     ],
     shell = "/bin/bash",
 )
+
+sh_cmd(
+    name = "dracon",
+    srcs = ["dracon.sh"],
+    cmd = """
+source "$(out_location :_util)"
+
+DRACON_BIN=$(out_exe //cmd/dracon)
+KIND_BIN=$(out_exe //third_party/tools:kind)
+source $SRCS
+    """,
+    data = [
+        "//cmd/dracon",
+        "//third_party/tools:kind",
+        ":_util",
+    ],
+    shell = "/bin/bash",
+)
+
+sh_cmd(
+    name = "_util",
+    srcs = ["util.sh"],
+    cmd = """
+source "$(out_location //scripts/util)"
+
+source $SRCS
+    """,
+    data = [
+        "//scripts/util",
+    ],
+    shell = "/bin/bash",
+)
+
 
 filegroup(
     name = "_configuration",

--- a/scripts/development/kind/dracon.sh
+++ b/scripts/development/kind/dracon.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# This script is a wrapper around dracon commands to give a 
+# development experience as close to the release experience as possible.
+# e.g. a released command could be `dracon setup --namespace dracon --pipeline examples/pipelines/python-project`
+# in development, we provide the ability to run this prefixed with `plz`, 
+# e.g. `plz dracon setup --namespace dracon --pipeline examples/pipelines/python-project`
+
+kubernetes_context=$(kubectl config current-context)
+if [ "${kubernetes_context}" != "kind-dracon" ]; then
+  util::prompt "Are you sure you would like to run dracon against '${kubernetes_context}'?"
+fi
+
+kind_cluster_name="${kubernetes_context//kind-/}"
+
+args=()
+while [ $# -gt 0 ]; do
+    case $1 in
+        --pipeline)
+            pipeline_target="//$2:dev"
+            if [[ "${args[@]}" == *"run "* ]]; then
+                util::load_development_images_into_kind "${kind_cluster_name}" "$pipeline_target"
+            fi
+
+            # convert pipeline flag to generated pipeline which has the local docker image tags
+            ./pleasew build "$pipeline_target"
+            pipeline_out_dir="$(dirname $(./pleasew query output $pipeline_target))"
+            args+=("$1" "$pipeline_out_dir")
+            shift 2
+        ;;
+        --*)
+            args+=("$1" "$2")
+            shift 2
+        ;;
+        *)
+            args+=("$1")
+            shift 1
+        ;;
+    esac
+done
+
+"$DRACON_BIN" "${args[@]}"

--- a/scripts/development/kind/util.sh
+++ b/scripts/development/kind/util.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# util::load_development_images_into_kind builds and loads the given target's Docker images into the KinD cluster.
+util::load_development_images_into_kind() {
+    local kind_cluster_name pipeline_target
+    kind_cluster_name="$1"
+    pipeline_target="$2"
+
+    docker_fqn_targets=($(./pleasew query deps \
+        --include docker-fqn \
+        "$pipeline_target" \
+        | sort -u \
+        | awk '{ print $1 }'
+    ))
+    if [ "${#docker_fqn_targets[@]}" == 0 ]; then
+        return
+    fi
+    util::rinfor "building ${#docker_fqn_targets[@]} image(s)"
+    docker_load_targets=($(printf '%s\n' "${docker_fqn_targets[@]}" | sed 's/_fqn$/_load/g'))
+    ./pleasew -p -v 2 --colour run parallel --quiet "${docker_load_targets[@]}"
+    for docker_fqn_target in "${docker_fqn_targets[@]}"; do
+        util::rinfor "loading $docker_fqn_target into kind cluster '$kind_cluster_name'"
+        docker_fqn=$(<$(./pleasew query output $docker_fqn_target))
+        "$KIND_BIN" load docker-image \
+            "${docker_fqn}" \
+            --name "${kind_cluster_name}" > /dev/null
+    done
+    util::rsuccess "loaded development images in to kind cluster '$kind_cluster_name'"
+}

--- a/source/git/BUILD
+++ b/source/git/BUILD
@@ -1,7 +1,8 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 docker_image(
     name = "dracon-source-git",
     srcs = ["git.sh"],
     image = "dracon-source-git",
+    visibility = ["//examples/..."],
 )

--- a/third_party/defs/BUILD
+++ b/third_party/defs/BUILD
@@ -1,0 +1,7 @@
+package(default_visibility = ["PUBLIC"])
+
+remote_file(
+    name = "docker",
+    url = "https://raw.githubusercontent.com/thought-machine/pleasings/7fa34bc749ff31008680f5d113ad958a73d84e07/docker/docker.build_defs",
+    hashes = ["9c0a6d6312dc36e23d8738d2d15d0dfa06cb996ab7f45e0d124cb6d65fbdb40f"],
+)

--- a/third_party/tools/BUILD
+++ b/third_party/tools/BUILD
@@ -20,3 +20,19 @@ remote_file(
     extract = True,
     visibility = ["//scripts/..."],
 )
+
+KUSTOMIZE_VERSION = "v3.8.7"
+
+remote_file(
+    name = "kustomize",
+    binary = True,
+    extract = True,
+    hashes = [
+        "4a3372d7bfdffe2eaf729e77f88bc94ce37dc84de55616bfe90aac089bf6fd02",  # linux-amd64
+    ],
+    url = f"https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F{KUSTOMIZE_VERSION}/kustomize_{KUSTOMIZE_VERSION}_{CONFIG.OS}_{CONFIG.ARCH}.tar.gz",
+    visibility = [
+        "//scripts/development/k8s/...",
+        "//examples/...",
+    ],
+)

--- a/tools/npm_audit/BUILD
+++ b/tools/npm_audit/BUILD
@@ -1,4 +1,4 @@
-subinclude("@third_party/subrepos/pleasings//docker")
+subinclude("//third_party/defs:docker")
 
 filegroup(
     name = "npm_audit",


### PR DESCRIPTION
This PR:
 * adds support for using Kustomize while developing Dracon.
 * Updates `plz dracon ...` to automatically build and load docker images into the local KinD cluster.
 * References pleasings/docker via a remote_file rather than downloading all of the repository.
 * Adds an initial WIP design document for distributing Dracon pipelines for end-users and allowing them to modify them with Kustomize.