### PR TITLE
Update Tekton and add Tekton Dashboard

### DIFF
--- a/scripts/development/k8s/tektoncd-dashboard/BUILD
+++ b/scripts/development/k8s/tektoncd-dashboard/BUILD
@@ -1,0 +1,11 @@
+subinclude("//build/defs:kustomize")
+
+kustomized_config(
+    name = "tektoncd-dashboard",
+    srcs = [
+        "//third_party/k8s:tektoncd_dashboard",
+        "ingress.yaml",
+        "kustomization.yaml",
+    ],
+    visibility = ["//scripts/development/..."],
+)

--- a/scripts/development/k8s/tektoncd-dashboard/ingress.yaml
+++ b/scripts/development/k8s/tektoncd-dashboard/ingress.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "http"
+spec:
+  backend:
+    serviceName: tekton-dashboard
+    servicePort: webinterface
+  tls:
+  - hosts:
+    - "dashboard.localhost"
+    secretName: tls-tekton-dashboard
+  rules:
+  - host: "dashboard.localhost"
+    http:
+      paths:
+      - backend:
+          serviceName: tekton-dashboard
+          servicePort: http

--- a/scripts/development/k8s/tektoncd-dashboard/kustomization.yaml
+++ b/scripts/development/k8s/tektoncd-dashboard/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tekton-pipelines
+
+resources:
+- ingress.yaml
+- //third_party/k8s:tektoncd_dashboard

--- a/scripts/development/kind/BUILD
+++ b/scripts/development/kind/BUILD
@@ -14,6 +14,7 @@ KUBERNETES_INGRESSNGINX_CONFIG="$(out_location //scripts/development/kind/ingres
 JETSTACK_CERTMANAGER_INSTALL="$(out_location //third_party/k8s:jetstack_certmanager)"
 
 TEKTONCD_PIPELINE_INSTALL="$(out_location //third_party/k8s:tektoncd_pipeline)"
+TEKTONCD_DASHBOARD_INSTALL="$(out_location //scripts/development/k8s/tektoncd-dashboard)"
 
 source $SRCS
     """,
@@ -25,6 +26,7 @@ source $SRCS
         "//third_party/k8s:jetstack_certmanager",
         "//scripts/development/kind/ingress:ingress-nginx",
         "//third_party/k8s:tektoncd_pipeline",
+        "//scripts/development/k8s/tektoncd-dashboard",
         ":_configuration",
     ],
     shell = "/bin/bash",

--- a/scripts/development/kind/configuration.yaml
+++ b/scripts/development/kind/configuration.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.16.15@sha256:c10a63a5bda231c0a379bf91aebf8ad3c79146daca59db816fb963f731852a99
+  image: kindest/node:v1.17.17@sha256:7b6369d27eee99c7a85c48ffd60e11412dc3f373658bc59b7f4d530b7056823e
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration

--- a/scripts/development/kind/setup.sh
+++ b/scripts/development/kind/setup.sh
@@ -41,6 +41,12 @@ $kubectl apply -f "${TEKTONCD_PIPELINE_INSTALL}" > /dev/null
 util::waitForRollout "${TEKTONCD_PIPELINE_INSTALL}"
 util::rsuccess "Installed tektoncd/pipeline"
 
+# tektoncd/dashboard
+util::infor "Installing tektoncd/dashboard"
+$kubectl apply -f "${TEKTONCD_DASHBOARD_INSTALL}" > /dev/null
+util::waitForRollout "${TEKTONCD_DASHBOARD_INSTALL}"
+util::rsuccess "Installed tektoncd/dashboard"
+
 
 # Finish
 if [ "$(kubectl config current-context)" != "${kubernetes_context}" ]; then

--- a/third_party/k8s/BUILD
+++ b/third_party/k8s/BUILD
@@ -13,9 +13,16 @@ remote_file(
     visibility = ["//scripts/development/kind/..."],
 )
 
-TEKTONCD_PIPELINE_VERSION="0.9.0"
+TEKTONCD_PIPELINE_VERSION="0.22.0"
 remote_file(
     name = "tektoncd_pipeline",
     url = f"https://github.com/tektoncd/pipeline/releases/download/v{TEKTONCD_PIPELINE_VERSION}/release.yaml",
+    visibility = ["//scripts/development/..."],
+)
+
+TEKTONCD_DASHBOARD_VERSION="0.15.0"
+remote_file(
+    name = "tektoncd_dashboard",
+    url = f"https://github.com/tektoncd/dashboard/releases/download/v{TEKTONCD_DASHBOARD_VERSION}/tekton-dashboard-release-readonly.yaml",
     visibility = ["//scripts/development/..."],
 )


### PR DESCRIPTION
This PR:
 * Updates Tekton Pipelines to v0.22.0 (and K8s to 1.17 to support this)
 * Adds Tekton Dashboard available at https://dashboard.localhost
