### PR TITLE
Add support for E2E against multiple k8s versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,9 @@ jobs:
   build:
     name: E2E
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kubernetes: ["1.16", "1.17", "1.18"]
     steps:
       - name: Install python dependencies
         run: sudo apt-get update && sudo apt-get install -y python3-setuptools python3-pip
@@ -12,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Create KinD cluster
-        run: ./pleasew run //scripts/development/kind:setup
+        run: ./pleasew run //scripts/development/kind:setup -- --kubernetes_version="${{ matrix.kubernetes }}"
 
       - name: Deploy Dracon supporting resources
         run: |

--- a/scripts/development/kind/configuration.yaml
+++ b/scripts/development/kind/configuration.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.17.17@sha256:7b6369d27eee99c7a85c48ffd60e11412dc3f373658bc59b7f4d530b7056823e
+  image: ___KIND_IMAGE___
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration

--- a/scripts/development/kind/setup.sh
+++ b/scripts/development/kind/setup.sh
@@ -3,13 +3,24 @@
 set -Eeuo pipefail
 
 DEFINE_string 'kind_cluster' 'dracon' 'Kind cluster to use' 'c'
+DEFINE_string 'kubernetes_version' '1.17' 'Kubernetes version to use' 'k'
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
+
+kubernetes_version="${FLAGS_kubernetes_version//./_}"
+
+declare -A KUBERNETES_VERSIONS
+KUBERNETES_VERSIONS=(
+  ["1_16"]="kindest/node:v1.16.15@sha256:c10a63a5bda231c0a379bf91aebf8ad3c79146daca59db816fb963f731852a99"
+  ["1_17"]="kindest/node:v1.17.17@sha256:7b6369d27eee99c7a85c48ffd60e11412dc3f373658bc59b7f4d530b7056823e"
+  ["1_18"]="kindest/node:v1.18.15@sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4"
+)
 
 kubernetes_context="kind-${FLAGS_kind_cluster}"
 
 if ! $KIND_BIN get clusters | grep "${FLAGS_kind_cluster}" 2>&1 > /dev/null; then
-  util::info "Creating KinD cluster ${FLAGS_kind_cluster}"
+  util::info "Creating KinD cluster ${FLAGS_kind_cluster} (${FLAGS_kubernetes_version})"
+  sed -i "s#___KIND_IMAGE___#${KUBERNETES_VERSIONS[$kubernetes_version]}#" "${KIND_CONFIG}"
   $KIND_BIN create cluster --name dracon --config "${KIND_CONFIG}"
   util::success "Created KinD cluster"
   kubectl config use-context "${kubernetes_context}"

--- a/third_party/k8s/BUILD
+++ b/third_party/k8s/BUILD
@@ -2,6 +2,7 @@ KUBERNETES_INGRESSNGINX_VERSION = "3.25.0"
 
 remote_file(
     name = "kubernetes_ingressnginx",
+    hashes = ["5cea6ce0f7e285f88847852aab05902406a63bfe4aef297831ea0207111fae44"],
     url = f"https://raw.githubusercontent.com/kubernetes/ingress-nginx/helm-chart-{KUBERNETES_INGRESSNGINX_VERSION}/deploy/static/provider/kind/deploy.yaml",
     visibility = ["//scripts/development/kind/..."],
 )
@@ -10,22 +11,25 @@ JETSTACK_CERTMANAGER_VERSION = "1.1.0"
 
 remote_file(
     name = "jetstack_certmanager",
+    hashes = ["651857a32b0be92f3c5c274729eea9c34bd457726bd3f560b3f68399659d1cfd"],
     url = f"https://github.com/jetstack/cert-manager/releases/download/v{JETSTACK_CERTMANAGER_VERSION}/cert-manager.yaml",
     visibility = ["//scripts/development/kind/..."],
 )
 
-TEKTONCD_PIPELINE_VERSION = "0.22.0"
+TEKTONCD_PIPELINE_VERSION = "0.19.0"
 
 remote_file(
     name = "tektoncd_pipeline",
+    hashes = ["a6a9049595137ec95cd50f8c0767a01cf54e941f7b2381710596f1bc4f8db29b"],
     url = f"https://github.com/tektoncd/pipeline/releases/download/v{TEKTONCD_PIPELINE_VERSION}/release.yaml",
     visibility = ["//scripts/development/..."],
 )
 
-TEKTONCD_DASHBOARD_VERSION = "0.15.0"
+TEKTONCD_DASHBOARD_VERSION = "0.14.0"
 
 remote_file(
     name = "tektoncd_dashboard",
+    hashes = ["938edf9e16fdc91585a944b8f50182638fd5b653ac1311bfac73be768e2a730c"],
     url = f"https://github.com/tektoncd/dashboard/releases/download/v{TEKTONCD_DASHBOARD_VERSION}/tekton-dashboard-release-readonly.yaml",
     visibility = ["//scripts/development/..."],
 )


### PR DESCRIPTION
This PR:
 * Adds a GitHub Actions matrix to ensure we support our E2E running of Dracon against multiple Kubernetes versions
 * Downgrades TektonCD pipelines to versions which support K8s 1.16 until we remove support for K8s 1.16.
 * Adds verification hashes for k8s remote files