### PR TITLE
Add ZAP producer

### DIFF
--- a/producers/zap_producer/BUILD
+++ b/producers/zap_producer/BUILD
@@ -1,0 +1,36 @@
+subinclude("//third_party/defs:docker")
+
+go_binary(
+    name = "zap",
+    srcs = [
+        "main.go",
+    ],
+    deps = [
+        "//api/proto:v1",
+        "//producers",
+        "//producers/zap_producer/types",
+    ],
+)
+
+go_test(
+    name = "zap_test",
+    srcs = [
+        "main.go",
+        "main_test.go",
+    ],
+    deps = [
+        "//api/proto:v1",
+        "//producers",
+        "//producers/zap_producer/types",
+        "//third_party/go:stretchr_testify",
+    ],
+)
+
+docker_image(
+    name = "dracon-producer-zap",
+    srcs = [
+        ":zap",
+    ],
+    base_image = "//build/docker:dracon-base-go",
+    image = "dracon-producer-zap",
+)

--- a/producers/zap_producer/Dockerfile
+++ b/producers/zap_producer/Dockerfile
@@ -1,0 +1,5 @@
+FROM //build/docker:dracon-base-go
+
+COPY zap /parse
+
+ENTRYPOINT ["/parse"]

--- a/producers/zap_producer/main.go
+++ b/producers/zap_producer/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
+	"github.com/thought-machine/dracon/producers/zap_producer/types"
+
+	"fmt"
+	"log"
+
+	"github.com/thought-machine/dracon/producers"
+
+)
+
+func main() {
+	if err := producers.ParseFlags(); err != nil {
+		log.Fatal(err)
+	}
+
+	inFile, err := producers.ReadInFile()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var results types.ZapOut
+	if err := producers.ParseJSON(inFile, &results); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := producers.WriteDraconOut(
+		"zap",
+		parseOut(&results),
+	); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func parseOut(results *types.ZapOut) []*v1.Issue {
+	issues := []*v1.Issue{}
+	for _, res := range results.Site{
+		target:= res.Name
+		for _, alert := range res.Alerts {
+			issues = append (issues, parseIssue(&alert, target))
+		}
+	}
+	return issues
+}
+
+//zap doesn't provide cvss so assigned as 0.0
+func parseIssue(r *types.ZapAlerts, target string) *v1.Issue {
+	var cvss = 0.0
+	return &v1.Issue{
+		Target:     target,
+		Type:       r.CweId,
+		Title:      r.Name ,
+		Severity:   riskcodeToSeverity(r.RiskCode),
+		Confidence: zapconfidenceToConfidence(r.Confidence),
+		Cvss:       cvss,
+		Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n", r.Description, r.Solution, r.Reference),
+	}
+}
+
+//riskcode values are 0-INFO,1-LOW,2-MEDIUM,3-HIGH only available from ZAP. It is determined by the ZAP contributors 
+func riskcodeToSeverity(riskcode string) v1.Severity {
+
+	if (riskcode == "0") {
+
+		return v1.Severity_SEVERITY_INFO
+
+	} else if (riskcode == "1") {
+
+		return v1.Severity_SEVERITY_LOW
+
+	} else if (riskcode == "2") {
+
+		return v1.Severity_SEVERITY_MEDIUM
+
+	} else if (riskcode == "3") {
+
+		return v1.Severity_SEVERITY_HIGH
+
+	} else if (riskcode == "4") {
+
+		return v1.Severity_SEVERITY_CRITICAL
+
+	} else {
+
+		return v1.Severity_SEVERITY_CRITICAL
+	}	
+}
+
+//Confidence values are 0-INFO,1-LOW,2-MEDIUM,3-HIGH only available from ZAP. It is determined by the ZAP contributors 
+func zapconfidenceToConfidence(confidence string) v1.Confidence {
+
+		if (confidence == "0") {
+	
+			return v1.Confidence_CONFIDENCE_INFO
+	
+		} else if (confidence == "1") {
+	
+			return v1.Confidence_CONFIDENCE_LOW
+	
+		} else if (confidence == "2") {
+	
+			return v1.Confidence_CONFIDENCE_MEDIUM
+	
+		} else if (confidence == "3") {
+	
+			return v1.Confidence_CONFIDENCE_HIGH
+	
+		} else if (confidence == "4") {
+
+			return v1.Confidence_CONFIDENCE_CRITICAL
+	
+		} else {
+			
+			return v1.Confidence_CONFIDENCE_CRITICAL
+		}	
+	}

--- a/producers/zap_producer/main.go
+++ b/producers/zap_producer/main.go
@@ -1,15 +1,12 @@
 package main
 
 import (
-
-	v1 "github.com/thought-machine/dracon/api/proto/v1"
-	"github.com/thought-machine/dracon/producers/zap_producer/types"
-
 	"fmt"
 	"log"
 
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
 	"github.com/thought-machine/dracon/producers"
-
+	"github.com/thought-machine/dracon/producers/zap_producer/types"
 )
 
 func main() {
@@ -27,20 +24,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := producers.WriteDraconOut(
-		"zap",
-		parseOut(&results),
-	); err != nil {
+	if err := producers.WriteDraconOut("zap", parseOut(&results)); err != nil {
 		log.Fatal(err)
 	}
 }
 
 func parseOut(results *types.ZapOut) []*v1.Issue {
 	issues := []*v1.Issue{}
-	for _, res := range results.Site{
-		target:= res.Name
+	for _, res := range results.Site {
+		target := res.Name
 		for _, alert := range res.Alerts {
-			issues = append (issues, parseIssue(&alert, target))
+			issues = append(issues, parseIssue(&alert, target))
 		}
 	}
 	return issues
@@ -48,72 +42,66 @@ func parseOut(results *types.ZapOut) []*v1.Issue {
 
 //zap doesn't provide cvss so assigned as 0.0
 func parseIssue(r *types.ZapAlerts, target string) *v1.Issue {
-	var cvss = 0.0
+	cvss := 0.0
 	return &v1.Issue{
-		Target:     target,
-		Type:       r.CweId,
-		Title:      r.Name ,
-		Severity:   riskcodeToSeverity(r.RiskCode),
-		Confidence: zapconfidenceToConfidence(r.Confidence),
-		Cvss:       cvss,
+		Target:      target,
+		Type:        r.CweId,
+		Title:       r.Name,
+		Severity:    riskcodeToSeverity(r.RiskCode),
+		Confidence:  zapconfidenceToConfidence(r.Confidence),
+		Cvss:        cvss,
 		Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n", r.Description, r.Solution, r.Reference),
 	}
 }
 
-//riskcode values are 0-INFO,1-LOW,2-MEDIUM,3-HIGH only available from ZAP. It is determined by the ZAP contributors 
+//riskcode values are 0-INFO,1-LOW,2-MEDIUM,3-HIGH only available from ZAP. It is determined by the ZAP contributors
 func riskcodeToSeverity(riskcode string) v1.Severity {
 
-	if (riskcode == "0") {
+	switch riskcode {
+	case "0":
 
 		return v1.Severity_SEVERITY_INFO
 
-	} else if (riskcode == "1") {
+	case "1":
 
 		return v1.Severity_SEVERITY_LOW
 
-	} else if (riskcode == "2") {
+	case "2":
 
 		return v1.Severity_SEVERITY_MEDIUM
 
-	} else if (riskcode == "3") {
+	case "3":
 
 		return v1.Severity_SEVERITY_HIGH
 
-	} else if (riskcode == "4") {
+	default:
 
 		return v1.Severity_SEVERITY_CRITICAL
-
-	} else {
-
-		return v1.Severity_SEVERITY_CRITICAL
-	}	
+	}
 }
 
-//Confidence values are 0-INFO,1-LOW,2-MEDIUM,3-HIGH only available from ZAP. It is determined by the ZAP contributors 
+//Confidence values are 0-INFO,1-LOW,2-MEDIUM,3-HIGH only available from ZAP. It is determined by the ZAP contributors
 func zapconfidenceToConfidence(confidence string) v1.Confidence {
 
-		if (confidence == "0") {
-	
-			return v1.Confidence_CONFIDENCE_INFO
-	
-		} else if (confidence == "1") {
-	
-			return v1.Confidence_CONFIDENCE_LOW
-	
-		} else if (confidence == "2") {
-	
-			return v1.Confidence_CONFIDENCE_MEDIUM
-	
-		} else if (confidence == "3") {
-	
-			return v1.Confidence_CONFIDENCE_HIGH
-	
-		} else if (confidence == "4") {
+	switch confidence {
+	case "0":
 
-			return v1.Confidence_CONFIDENCE_CRITICAL
-	
-		} else {
-			
-			return v1.Confidence_CONFIDENCE_CRITICAL
-		}	
+		return v1.Confidence_CONFIDENCE_INFO
+
+	case "1":
+
+		return v1.Confidence_CONFIDENCE_LOW
+
+	case "2":
+
+		return v1.Confidence_CONFIDENCE_MEDIUM
+
+	case "3":
+
+		return v1.Confidence_CONFIDENCE_HIGH
+
+	default:
+
+		return v1.Confidence_CONFIDENCE_CRITICAL
 	}
+}

--- a/producers/zap_producer/main_test.go
+++ b/producers/zap_producer/main_test.go
@@ -1,148 +1,140 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"testing"
 
 	v1 "github.com/thought-machine/dracon/api/proto/v1"
 	"github.com/thought-machine/dracon/producers/zap_producer/types"
-
-    "fmt"
-	"encoding/json"
-    "testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 var riskcodetests = []struct {
-    zapriskcode  string
-    severityissue v1.Severity
+	zapriskcode   string
+	severityissue v1.Severity
 }{
-    {"0", v1.Severity_SEVERITY_INFO},
-    {"1", v1.Severity_SEVERITY_LOW},
-    {"2", v1.Severity_SEVERITY_MEDIUM},
-    {"3", v1.Severity_SEVERITY_HIGH},
-    {"4", v1.Severity_SEVERITY_CRITICAL},
-    {"5", v1.Severity_SEVERITY_CRITICAL},
+	{"0", v1.Severity_SEVERITY_INFO},
+	{"1", v1.Severity_SEVERITY_LOW},
+	{"2", v1.Severity_SEVERITY_MEDIUM},
+	{"3", v1.Severity_SEVERITY_HIGH},
+	{"4", v1.Severity_SEVERITY_CRITICAL},
+	{"5", v1.Severity_SEVERITY_CRITICAL},
 }
 
 func TestZapRiskcodeToDraconSeverityParametrized(t *testing.T) {
-    for _, riskcode := range riskcodetests {
-         assert.EqualValues(t, riskcode.severityissue, riskcodeToSeverity(riskcode.zapriskcode))
-    }
+	for _, riskcode := range riskcodetests {
+		assert.EqualValues(t, riskcode.severityissue, riskcodeToSeverity(riskcode.zapriskcode))
+	}
 }
 
 var confidencetests = []struct {
-    zapconfidence  string
-    confidenceissue v1.Confidence
+	zapconfidence   string
+	confidenceissue v1.Confidence
 }{
-    {"0", v1.Confidence_CONFIDENCE_INFO},
-    {"1", v1.Confidence_CONFIDENCE_LOW},
-    {"2", v1.Confidence_CONFIDENCE_MEDIUM},
-    {"3", v1.Confidence_CONFIDENCE_HIGH},
-    {"4", v1.Confidence_CONFIDENCE_CRITICAL},
-    {"5", v1.Confidence_CONFIDENCE_CRITICAL},
+	{"0", v1.Confidence_CONFIDENCE_INFO},
+	{"1", v1.Confidence_CONFIDENCE_LOW},
+	{"2", v1.Confidence_CONFIDENCE_MEDIUM},
+	{"3", v1.Confidence_CONFIDENCE_HIGH},
+	{"4", v1.Confidence_CONFIDENCE_CRITICAL},
+	{"5", v1.Confidence_CONFIDENCE_CRITICAL},
 }
 
 func TestZapConfidenceToDraconConfidenceParametrized(t *testing.T) {
-    for _, confidence := range confidencetests {
-        assert.EqualValues(t, confidence.confidenceissue, zapconfidenceToConfidence(confidence.zapconfidence))
-    }
- }
+	for _, confidence := range confidencetests {
+		assert.EqualValues(t, confidence.confidenceissue, zapconfidenceToConfidence(confidence.zapconfidence))
+	}
+}
 
 func TestZapOutputWhenOneSiteAndOneAlert(t *testing.T) {
 	var results types.ZapOut
 	err := json.Unmarshal([]byte(exampleOutput1), &results)
-	if err != nil {
-        t.Logf(err.Error())
-		t.Fail()
+	assert.NoError(t, err)
+	issues := parseOut(&results)
+	expectedIssues := []*v1.Issue{
+		&v1.Issue{
+			Target:     "https://thisisanexample.com",
+			Type:       "16",
+			Title:      "X-Content-Type-Options Header Missing",
+			Severity:   v1.Severity_SEVERITY_LOW,
+			Cvss:       0.0,
+			Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
+			Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
+				"<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
+				"<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",
+				"<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx</p><p>https://owasp.org/www-community/Security_Headers</p>"),
+		},
 	}
-    issues := parseOut(&results)
-
-    expectedIssues := make([]*v1.Issue, 1)
-	expectedIssues[0] = &v1.Issue{
-		Target:     "https://thisisanexample.com",
-		Type:       "16",
-		Title:      "X-Content-Type-Options Header Missing",
-		Severity:   v1.Severity_SEVERITY_LOW,
-		Cvss:       0.0,
-		Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
-        Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
-        "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
-        "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",
-        "<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx</p><p>https://owasp.org/www-community/Security_Headers</p>"),
-	}
-    assert.Equal(t, len(expectedIssues), len(issues))
+	assert.Equal(t, len(expectedIssues), len(issues))
 
 	for _, issue := range issues {
-	 	for _, expected := range expectedIssues {
-                assert.EqualValues(t, expected.Target, issue.Target)
-                assert.EqualValues(t, expected.Type, issue.Type)
-                assert.EqualValues(t, expected.Title, issue.Title)
-	 			assert.EqualValues(t, expected.Severity, issue.Severity)
-	 			assert.EqualValues(t, expected.Cvss, issue.Cvss)
-	 			assert.EqualValues(t, expected.Confidence, issue.Confidence)
-	 			assert.EqualValues(t, expected.Description, issue.Description)
-	 	}
+		for _, expected := range expectedIssues {
+			assert.EqualValues(t, expected.Target, issue.Target)
+			assert.EqualValues(t, expected.Type, issue.Type)
+			assert.EqualValues(t, expected.Title, issue.Title)
+			assert.EqualValues(t, expected.Severity, issue.Severity)
+			assert.EqualValues(t, expected.Cvss, issue.Cvss)
+			assert.EqualValues(t, expected.Confidence, issue.Confidence)
+			assert.EqualValues(t, expected.Description, issue.Description)
+		}
 	}
 }
 
 func TestZapOutputWhenTwoSitesAndMultipleAlerts(t *testing.T) {
 	var results types.ZapOut
 	err := json.Unmarshal([]byte(exampleOutput2), &results)
-	if err != nil {
-        t.Logf(err.Error())
-		t.Fail()
+	assert.NoError(t, err)
+	issues := parseOut(&results)
+	expectedIssues := []*v1.Issue{
+		&v1.Issue{
+			Target:     "https://thisisanexample.com",
+			Type:       "16",
+			Title:      "X-Content-Type-Options Header Missing",
+			Severity:   v1.Severity_SEVERITY_LOW,
+			Cvss:       0.0,
+			Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
+			Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
+				"<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
+				"<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",
+				"<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx</p><p>https://owasp.org/www-community/Security_Headers</p>"),
+		},
+		&v1.Issue{
+			Target:     "https://thisisanexample.com",
+			Type:       "16",
+			Title:      "X-Frame-Options Header Not Set",
+			Severity:   v1.Severity_SEVERITY_MEDIUM,
+			Cvss:       0.0,
+			Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
+			Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
+				"<p>X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.</p>",
+				"<p>Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).</p>",
+				"<p>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options</p>"),
+		},
+		&v1.Issue{
+			Target:     "https://thisithesecondexample.com",
+			Type:       "16",
+			Title:      "X-Content-Type-Options Header Missing",
+			Severity:   v1.Severity_SEVERITY_LOW,
+			Cvss:       0.0,
+			Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
+			Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
+				"<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
+				"<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",
+				"<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx</p><p>https://owasp.org/www-community/Security_Headers</p>"),
+		},
 	}
-    issues := parseOut(&results)
-    
-	expectedIssues := make([]*v1.Issue, 3)
-	expectedIssues[0] = &v1.Issue{
-		Target:     "https://thisisanexample.com",
-		Type:       "16",
-		Title:      "X-Content-Type-Options Header Missing",
-		Severity:   v1.Severity_SEVERITY_LOW,
-		Cvss:       0.0,
-		Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
-        Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
-        "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
-        "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",            
-        "<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx</p><p>https://owasp.org/www-community/Security_Headers</p>"),
-	}
-	expectedIssues[1] = &v1.Issue{
-		Target:     "https://thisisanexample.com",
-		Type:       "16",
-		Title:      "X-Frame-Options Header Not Set",
-		Severity:   v1.Severity_SEVERITY_MEDIUM,
-		Cvss:       0.0,
-		Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
-        Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
-        "<p>X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.</p>",
-        "<p>Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).</p>",
-        "<p>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options</p>"),
-	}
-	expectedIssues[2] = &v1.Issue{
-		Target:     "https://thisithesecondexample.com",
-		Type:       "16",
-		Title:      "X-Content-Type-Options Header Missing",
-		Severity:   v1.Severity_SEVERITY_LOW,
-		Cvss:       0.0,
-		Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
-        Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
-        "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
-        "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",            
-        "<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx</p><p>https://owasp.org/www-community/Security_Headers</p>"),
-    }
-    assert.Equal(t, len(expectedIssues), len(issues))
-    for i, issue := range issues {
-                assert.EqualValues(t, expectedIssues[i].Target, issue.Target)
-                assert.EqualValues(t, expectedIssues[i].Type, issue.Type)
-                assert.EqualValues(t, expectedIssues[i].Title, issue.Title)
-	 			assert.EqualValues(t, expectedIssues[i].Severity, issue.Severity)
-	 			assert.EqualValues(t, expectedIssues[i].Cvss, issue.Cvss)
-	 			assert.EqualValues(t, expectedIssues[i].Confidence, issue.Confidence)
-                assert.EqualValues(t, expectedIssues[i].Description, issue.Description)
+	assert.Equal(t, len(expectedIssues), len(issues))
+	for i, issue := range issues {
+		assert.EqualValues(t, expectedIssues[i].Target, issue.Target)
+		assert.EqualValues(t, expectedIssues[i].Type, issue.Type)
+		assert.EqualValues(t, expectedIssues[i].Title, issue.Title)
+		assert.EqualValues(t, expectedIssues[i].Severity, issue.Severity)
+		assert.EqualValues(t, expectedIssues[i].Cvss, issue.Cvss)
+		assert.EqualValues(t, expectedIssues[i].Confidence, issue.Confidence)
+		assert.EqualValues(t, expectedIssues[i].Description, issue.Description)
 	}
 
-	
 }
 
 var exampleOutput1 = `{

--- a/producers/zap_producer/main_test.go
+++ b/producers/zap_producer/main_test.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
+	"github.com/thought-machine/dracon/producers/zap_producer/types"
+
+    "fmt"
+	"encoding/json"
+    "testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var riskcodetests = []struct {
+    zapriskcode  string
+    severityissue v1.Severity
+}{
+    {"0", v1.Severity_SEVERITY_INFO},
+    {"1", v1.Severity_SEVERITY_LOW},
+    {"2", v1.Severity_SEVERITY_MEDIUM},
+    {"3", v1.Severity_SEVERITY_HIGH},
+    {"4", v1.Severity_SEVERITY_CRITICAL},
+    {"5", v1.Severity_SEVERITY_CRITICAL},
+}
+
+func TestZapRiskcodeToDraconSeverityParametrized(t *testing.T) {
+    for _, riskcode := range riskcodetests {
+         assert.EqualValues(t, riskcode.severityissue, riskcodeToSeverity(riskcode.zapriskcode))
+    }
+}
+
+var confidencetests = []struct {
+    zapconfidence  string
+    confidenceissue v1.Confidence
+}{
+    {"0", v1.Confidence_CONFIDENCE_INFO},
+    {"1", v1.Confidence_CONFIDENCE_LOW},
+    {"2", v1.Confidence_CONFIDENCE_MEDIUM},
+    {"3", v1.Confidence_CONFIDENCE_HIGH},
+    {"4", v1.Confidence_CONFIDENCE_CRITICAL},
+    {"5", v1.Confidence_CONFIDENCE_CRITICAL},
+}
+
+func TestZapConfidenceToDraconConfidenceParametrized(t *testing.T) {
+    for _, confidence := range confidencetests {
+        assert.EqualValues(t, confidence.confidenceissue, zapconfidenceToConfidence(confidence.zapconfidence))
+    }
+ }
+
+func TestZapOutputWhenOneSiteAndOneAlert(t *testing.T) {
+	var results types.ZapOut
+	err := json.Unmarshal([]byte(exampleOutput1), &results)
+	if err != nil {
+        t.Logf(err.Error())
+		t.Fail()
+	}
+    issues := parseOut(&results)
+
+    expectedIssues := make([]*v1.Issue, 1)
+	expectedIssues[0] = &v1.Issue{
+		Target:     "https://thisisanexample.com",
+		Type:       "16",
+		Title:      "X-Content-Type-Options Header Missing",
+		Severity:   v1.Severity_SEVERITY_LOW,
+		Cvss:       0.0,
+		Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
+        Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
+        "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
+        "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",
+        "<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx</p><p>https://owasp.org/www-community/Security_Headers</p>"),
+	}
+    assert.Equal(t, len(expectedIssues), len(issues))
+
+	for _, issue := range issues {
+	 	for _, expected := range expectedIssues {
+                assert.EqualValues(t, expected.Target, issue.Target)
+                assert.EqualValues(t, expected.Type, issue.Type)
+                assert.EqualValues(t, expected.Title, issue.Title)
+	 			assert.EqualValues(t, expected.Severity, issue.Severity)
+	 			assert.EqualValues(t, expected.Cvss, issue.Cvss)
+	 			assert.EqualValues(t, expected.Confidence, issue.Confidence)
+	 			assert.EqualValues(t, expected.Description, issue.Description)
+	 	}
+	}
+}
+
+func TestZapOutputWhenTwoSitesAndMultipleAlerts(t *testing.T) {
+	var results types.ZapOut
+	err := json.Unmarshal([]byte(exampleOutput2), &results)
+	if err != nil {
+        t.Logf(err.Error())
+		t.Fail()
+	}
+    issues := parseOut(&results)
+    
+	expectedIssues := make([]*v1.Issue, 3)
+	expectedIssues[0] = &v1.Issue{
+		Target:     "https://thisisanexample.com",
+		Type:       "16",
+		Title:      "X-Content-Type-Options Header Missing",
+		Severity:   v1.Severity_SEVERITY_LOW,
+		Cvss:       0.0,
+		Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
+        Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
+        "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
+        "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",            
+        "<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx</p><p>https://owasp.org/www-community/Security_Headers</p>"),
+	}
+	expectedIssues[1] = &v1.Issue{
+		Target:     "https://thisisanexample.com",
+		Type:       "16",
+		Title:      "X-Frame-Options Header Not Set",
+		Severity:   v1.Severity_SEVERITY_MEDIUM,
+		Cvss:       0.0,
+		Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
+        Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
+        "<p>X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.</p>",
+        "<p>Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).</p>",
+        "<p>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options</p>"),
+	}
+	expectedIssues[2] = &v1.Issue{
+		Target:     "https://thisithesecondexample.com",
+		Type:       "16",
+		Title:      "X-Content-Type-Options Header Missing",
+		Severity:   v1.Severity_SEVERITY_LOW,
+		Cvss:       0.0,
+		Confidence: v1.Confidence_CONFIDENCE_MEDIUM,
+        Description: fmt.Sprintf("Description: %s\nSolution: %s\nReference: %s\n",
+        "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
+        "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",            
+        "<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx</p><p>https://owasp.org/www-community/Security_Headers</p>"),
+    }
+    assert.Equal(t, len(expectedIssues), len(issues))
+    for i, issue := range issues {
+                assert.EqualValues(t, expectedIssues[i].Target, issue.Target)
+                assert.EqualValues(t, expectedIssues[i].Type, issue.Type)
+                assert.EqualValues(t, expectedIssues[i].Title, issue.Title)
+	 			assert.EqualValues(t, expectedIssues[i].Severity, issue.Severity)
+	 			assert.EqualValues(t, expectedIssues[i].Cvss, issue.Cvss)
+	 			assert.EqualValues(t, expectedIssues[i].Confidence, issue.Confidence)
+                assert.EqualValues(t, expectedIssues[i].Description, issue.Description)
+	}
+
+	
+}
+
+var exampleOutput1 = `{
+    "@version": "2.10.0",
+    "@generated": "Tue, 25 May 2021 15:19:04",
+    "site": [
+        {
+            "@name": "https://thisisanexample.com",
+            "@host": "thisisanexample.com",
+            "@port": "443",
+            "@ssl": "true",
+            "alerts": [
+                {
+                    "pluginid": "10021",
+                    "alertRef": "10021",
+                    "alert": "X-Content-Type-Options Header Missing",
+                    "name": "X-Content-Type-Options Header Missing",
+                    "riskcode": "1",
+                    "confidence": "2",
+                    "riskdesc": "Low (Medium)",
+                    "desc": "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.<\/p>",
+                    "instances": [
+                        {
+                            "uri": "https://thisisanexample.com/sso?SAMLRequest=lZLLbsIwEEX3fEWUfZ4ktFiBTKcG2vEGrdShz%2BhcHXw%3D%3D&RelayState=https%3A%2F%2Fthisisanexample.com%2F",
+                            "method": "GET",
+                            "param": "X-Content-Type-Options"
+                        },
+                        {
+                            "uri": "https://thisisanexample.com/sso",
+                            "method": "POST",
+                            "param": "X-Content-Type-Options"
+                        }
+                    ],
+                    "count": "2",
+                    "solution": "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.<\/p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.<\/p>",
+                    "otherinfo": "<p>This issue still applies to error type pages (401, 403, 500, etc.) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.<\/p><p>At \"High\" threshold this scan rule will not alert on client or server error responses.<\/p>",
+                    "reference": "<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx<\/p><p>https://owasp.org/www-community/Security_Headers<\/p>",
+                    "cweid": "16",
+                    "wascid": "15",
+                    "sourceid": "3"
+                }
+            ]
+        }
+    ]
+}`
+
+var exampleOutput2 = ` {
+    "@version": "2.10.0",
+    "@generated": "Tue, 25 May 2021 15:19:04",
+    "site": [
+        {
+            "@name": "https://thisisanexample.com",
+            "@host": "thisisanexample.com",
+            "@port": "443",
+            "@ssl": "true",
+            "alerts": [
+                {
+                    "pluginid": "10021",
+                    "alertRef": "10021",
+                    "alert": "X-Content-Type-Options Header Missing",
+                    "name": "X-Content-Type-Options Header Missing",
+                    "riskcode": "1",
+                    "confidence": "2",
+                    "riskdesc": "Low (Medium)",
+                    "desc": "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.<\/p>",
+                    "instances": [
+                        {
+                            "uri": "https://thisisanexample.com/sso?SAMLRequest=lZLex2Or%2BkFZY5mBWYvUzhaTk9VtEFnmvCC9k09XiK9Xw%3D%3D&RelayState=https%3A%2F%2Fthisisanexample.com%2F",
+                            "method": "GET",
+                            "param": "X-Content-Type-Options"
+                        },
+                        {
+                            "uri": "https://thisisanexample.com/sso",
+                            "method": "POST",
+                            "param": "X-Content-Type-Options"
+                        }
+                    ],
+                    "count": "2",
+                    "solution": "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.<\/p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.<\/p>",
+                    "otherinfo": "<p>This issue still applies to error type pages (401, 403, 500, etc.) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.<\/p><p>At \"High\" threshold this scan rule will not alert on client or server error responses.<\/p>",
+                    "reference": "<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx<\/p><p>https://owasp.org/www-community/Security_Headers<\/p>",
+                    "cweid": "16",
+                    "wascid": "15",
+                    "sourceid": "3"
+                },
+                {
+                    "pluginid": "10020",
+                    "alertRef": "10020",
+                    "alert": "X-Frame-Options Header Not Set",
+                    "name": "X-Frame-Options Header Not Set",
+                    "riskcode": "2",
+                    "confidence": "2",
+                    "riskdesc": "Medium (Medium)",
+                    "desc": "<p>X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.<\/p>",
+                    "instances": [
+                        {
+                            "uri": "https://thisisanexample.com/sso?SAMLRequest=lZLex2Or%2BkFZY5mBWYvUzhaTk9VtEFnmvCC9k09XiK9Xw%3D%3D&RelayState=https%3A%2F%2Fthisisanexample.com%2F",
+                            "method": "GET",
+                            "param": "X-Frame-Options"
+                        },
+                        {
+                            "uri": "https://thisisanexample.com/sso",
+                            "method": "POST",
+                            "param": "X-Frame-Options"
+                        }
+                    ],
+                    "count": "2",
+                    "solution": "<p>Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).<\/p>",
+                    "reference": "<p>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options<\/p>",
+                    "cweid": "16",
+                    "wascid": "15",
+                    "sourceid": "3"
+                }
+            ]
+        },
+        {
+            "@name": "https://thisithesecondexample.com",
+            "@host": "thisithesecondexample.com",
+            "@port": "443",
+            "@ssl": "true",
+            "alerts": [
+                {
+                    "pluginid": "10021",
+                    "alertRef": "10021",
+                    "alert": "X-Content-Type-Options Header Missing",
+                    "name": "X-Content-Type-Options Header Missing",
+                    "riskcode": "1",
+                    "confidence": "2",
+                    "riskdesc": "Low (Medium)",
+                    "desc": "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.<\/p>",
+                    "instances": [
+                        {
+                            "uri": "https://thisithesecondexample.com",
+                            "method": "GET",
+                            "param": "X-Content-Type-Options"
+                        }
+                    ],
+                    "count": "9",
+                    "solution": "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.<\/p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.<\/p>",
+                    "otherinfo": "<p>This issue still applies to error type pages (401, 403, 500, etc.) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.<\/p><p>At \"High\" threshold this scan rule will not alert on client or server error responses.<\/p>",
+                    "reference": "<p>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx<\/p><p>https://owasp.org/www-community/Security_Headers<\/p>",
+                    "cweid": "16",
+                    "wascid": "15",
+                    "sourceid": "3"
+                }
+            ]
+        }
+    ]
+}`

--- a/producers/zap_producer/types/BUILD
+++ b/producers/zap_producer/types/BUILD
@@ -1,0 +1,7 @@
+go_library(
+    name = "types",
+    srcs = [
+        "zap-issue.go",
+    ],
+    visibility = ["//producers/zap_producer/..."],
+)

--- a/producers/zap_producer/types/zap-issue.go
+++ b/producers/zap_producer/types/zap-issue.go
@@ -2,42 +2,42 @@ package types
 
 // ZapOut represents the output of a zap scan
 type ZapOut struct {
-	Version 	string 			`json:"@version"`
-	Generated 	string 			`json:"@generated"`
-	Site    []ZapSites 		 	`json:"site"`
+	Version   string     `json:"@version"`
+	Generated string     `json:"@generated"`
+	Site      []ZapSites `json:"site"`
 }
 
 // ZapSite represents a zap site section
 type ZapSites struct {
-	Name     	string           `json:"@name"`
-	Host       	string           `json:"@host"`
-	Port     	string           `json:"@port"`
-	Ssl       	string           `json:"@ssl"`
-	Alerts []ZapAlerts			 `json:"alerts"`
+	Name   string      `json:"@name"`
+	Host   string      `json:"@host"`
+	Port   string      `json:"@port"`
+	Ssl    string      `json:"@ssl"`
+	Alerts []ZapAlerts `json:"alerts"`
 }
 
-// ZapInstances represents a zap occurence for a specific alert
+// ZapInstances represents a zap occurrence for a specific alert
 type ZapInstances struct {
-	Uri    		string           `json:"uri"`
-	Method   	string           `json:"method"`
+	Uri    string `json:"uri"`
+	Method string `json:"method"`
 }
 
 // ZapAlert represents a zap vulnerability
 type ZapAlerts struct {
-	PluginId    string 			`json:"Id"`
-	AlertRef    string 			`json:"alertRef"`
-	Alert 		string 			`json:"alert"`
-	Name   		string 			`json:"name"`
-	RiskCode  	string 			`json:"riskcode"`
-	Confidence  string 			`json:"confidence"`
-	RiskDesc 	string 			`json:"riskdesc"`
-	Description string 			`json:"desc"`
-	Instances  []ZapInstances  	`json:"instances"`
-	Count       string 			`json:"count"`
-	Solution    string 			`json:"solution"`
-	OtherInfo   string 			`json:"otherinfo"`
-	Reference   string 			`json:"reference"`
-	CweId       string 			`json:"cweid"`
-	WascId      string 			`json:"wascid"`
-	SourceId   	string 			`json:"sourceid"`
+	PluginId    string         `json:"Id"`
+	AlertRef    string         `json:"alertRef"`
+	Alert       string         `json:"alert"`
+	Name        string         `json:"name"`
+	RiskCode    string         `json:"riskcode"`
+	Confidence  string         `json:"confidence"`
+	RiskDesc    string         `json:"riskdesc"`
+	Description string         `json:"desc"`
+	Instances   []ZapInstances `json:"instances"`
+	Count       string         `json:"count"`
+	Solution    string         `json:"solution"`
+	OtherInfo   string         `json:"otherinfo"`
+	Reference   string         `json:"reference"`
+	CweId       string         `json:"cweid"`
+	WascId      string         `json:"wascid"`
+	SourceId    string         `json:"sourceid"`
 }

--- a/producers/zap_producer/types/zap-issue.go
+++ b/producers/zap_producer/types/zap-issue.go
@@ -1,0 +1,43 @@
+package types
+
+// ZapOut represents the output of a zap scan
+type ZapOut struct {
+	Version 	string 			`json:"@version"`
+	Generated 	string 			`json:"@generated"`
+	Site    []ZapSites 		 	`json:"site"`
+}
+
+// ZapSite represents a zap site section
+type ZapSites struct {
+	Name     	string           `json:"@name"`
+	Host       	string           `json:"@host"`
+	Port     	string           `json:"@port"`
+	Ssl       	string           `json:"@ssl"`
+	Alerts []ZapAlerts			 `json:"alerts"`
+}
+
+// ZapInstances represents a zap occurence for a specific alert
+type ZapInstances struct {
+	Uri    		string           `json:"uri"`
+	Method   	string           `json:"method"`
+}
+
+// ZapAlert represents a zap vulnerability
+type ZapAlerts struct {
+	PluginId    string 			`json:"Id"`
+	AlertRef    string 			`json:"alertRef"`
+	Alert 		string 			`json:"alert"`
+	Name   		string 			`json:"name"`
+	RiskCode  	string 			`json:"riskcode"`
+	Confidence  string 			`json:"confidence"`
+	RiskDesc 	string 			`json:"riskdesc"`
+	Description string 			`json:"desc"`
+	Instances  []ZapInstances  	`json:"instances"`
+	Count       string 			`json:"count"`
+	Solution    string 			`json:"solution"`
+	OtherInfo   string 			`json:"otherinfo"`
+	Reference   string 			`json:"reference"`
+	CweId       string 			`json:"cweid"`
+	WascId      string 			`json:"wascid"`
+	SourceId   	string 			`json:"sourceid"`
+}


### PR DESCRIPTION
Support ZAP as a Dracon producer. 
Currently, it parses the results of a ZAP scan JSON output.

Please note: The issue description will contain the description of the finding and additional information such as resolution and reference. 