### PR TITLE
truncate summary and add the extra to description

### DIFF
--- a/common/jira/jira/api.go
+++ b/common/jira/jira/api.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 
@@ -46,12 +47,17 @@ func (client client) assembleIssue(draconResult map[string]string) *jira.Issue {
 	for _, m := range client.Config.Mappings {
 		customFields[m.JiraField] = makeCustomField(m.FieldType, []string{draconResult[m.DraconField]})
 	}
+	summary, extra := makeSummary(draconResult)
+	description := makeDescription(draconResult, client.Config.DescriptionExtras)
+	if extra != "" {
+		description = fmt.Sprintf(".... %s\n%s", extra, description)
+	}
 	return &jira.Issue{
 		Fields: &jira.IssueFields{
 			Project:         client.DefaultFields.Project,
 			Type:            client.DefaultFields.IssueType,
-			Description:     makeDescription(draconResult, client.Config.DescriptionExtras),
-			Summary:         makeSummary(draconResult),
+			Description:     description,
+			Summary:         summary,
 			Components:      client.DefaultFields.Components,
 			AffectsVersions: client.DefaultFields.AffectsVersions,
 			Labels:          client.DefaultFields.Labels,

--- a/common/jira/jira/apiutils.go
+++ b/common/jira/jira/apiutils.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -102,6 +103,14 @@ func makeDescription(draconResult map[string]string, extras []string) string {
 }
 
 // makeSummary creates the Summary/Title of an issue
-func makeSummary(draconResult map[string]string) string {
-	return filepath.Base(draconResult["target"]) + " " + draconResult["title"]
+func makeSummary(draconResult map[string]string) (string, string) {
+	summary := filepath.Base(draconResult["target"]) + " " + draconResult["title"]
+
+	if len(summary) > 255 { // jira summary field supports up to 255 chars
+		tobytes := bytes.Runes([]byte(summary))
+		summary = string(tobytes[:254])
+		extra := string(tobytes[255:])
+		return summary, extra
+	}
+	return summary, ""
 }

--- a/common/jira/jira/apiutils_test.go
+++ b/common/jira/jira/apiutils_test.go
@@ -73,8 +73,37 @@ func TestMakeDescription(t *testing.T) {
 }
 
 func TestMakeSummary(t *testing.T) {
-	res := makeSummary(sampleResult)
+	res, extra := makeSummary(sampleResult)
 	exp := "bar1:baz2 Unit Test Title"
-
 	assert.Equal(t, res, exp)
+	assert.Equal(t, extra, "")
+
+	longTitle := make([]rune, 300)
+	truncatedSummary := make([]rune, 254)
+	expectedExtra := make([]rune, 49)
+	char := []rune{'\u0061'} // 'a'
+	for i := range longTitle {
+		longTitle[i] = char[0]
+	}
+
+	// truncatedSummary = []rune{'b','a','r',' '}
+	for i := 4; i < len(truncatedSummary); i++ {
+		truncatedSummary[i] = char[0]
+	}
+	truncatedSummary[0] = 'b'
+	truncatedSummary[1] = 'a'
+	truncatedSummary[2] = 'r'
+	truncatedSummary[3] = ' '
+
+	for i := range expectedExtra {
+		expectedExtra[i] = char[0]
+	}
+	sampleResult["target"] = "/foo/bar"
+	sampleResult["title"] = string(longTitle)
+
+	res, extra = makeSummary(sampleResult)
+	assert.Equal(t, string(truncatedSummary), res)
+
+	assert.Equal(t, string(expectedExtra), extra)
+
 }


### PR DESCRIPTION
jira summary field is capped at 255 characters, the jira consumer needs to truncate longer summaries and add the extra parts in the description