### PR TITLE
since pip does not deterministically build packages, remove inconsist…

### DIFF
--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -14,11 +14,7 @@ pip_library(
 
 pip_library(
     name = "protobuf",
-    hashes = [
-        "f958e27563875e4e4374cf4fce3c061f2f7742faa1139acf8def40da07e0ce4e",  # TM Mirror
-        "912fa826e4b9a16947853ca163c18ad530a42a159de357769052443898cae473",  # Public
-        "95dfa3e09ff6a00dd9a02a250d82255d43a2a2b48144c034ee313efd15fd73da",  # GitHub Actions
-    ],
+    hashes = [],
     licences = ["BSD 3-Clause"],
     version = "3.11.3",
     deps = [":six"],
@@ -39,23 +35,14 @@ pip_library(
 pip_library(
     name = "six",
     package_name = "six",
-    # outs = ["six.py"],
-    hashes = [
-        "4c468c181cb3dd03c3eb368940cb008d6d45bad48ee085d3f9655a15dc6603f4",  # TM Mirror
-        "73031963564bba0bd0bbae94736110f52dc927f6f09c0627edf6f98a033ce669",  # Public
-        "a1f4385f169be6c75c37e2f656fecbc5a014dda92357cf8509a4a651d35ae141",  # GitHub Actions
-    ],
+    hashes = [],
     licences = ["MIT"],
     version = "1.14.0",
 )
 
 pip_library(
     name = "requests",
-    hashes = [
-        "a749c5c5d6f10ab3ac2a0e46b5459b829a93b0ef08dec412236d5abde75d94f7",  # TM Mirror
-        "66fa77b628df4eb564b5bb06117e0c8f756acc2865115d6ec89f05b31d20f471",  # Public
-        "13308be8e327c460966a1b6f89ddf3ceccc70fe60923888ab6a35542cae495fe",  # GitHub Actions
-    ],
+    hashes = [],
     version = "2.23.0",
     deps = [
         ":certifi",
@@ -67,50 +54,31 @@ pip_library(
 
 pip_library(
     name = "urllib3",
-    hashes = [
-        "dfadcc16d8b81f332c6c4e4d54fa85baec2a94d5a3aab593e705b0f7d30c4494",  # TM Mirror
-        "37b6e0d114199eb1edbde76b07e13efaa41331f4c79690d08f38a95368bbf0d2",  # Public
-        "d9bb0ea061189e901e9919934c23723749a329d5aa5bb53397ed1af038e1e9c9",  # GitHub Actions
-    ],
+    hashes = [],
     version = "1.25.8",
 )
 
 pip_library(
     name = "certifi",
-    hashes = [
-        "98e5784d3d46c6b61d9ecc2a2692ecf989eb0b5e72899ab52ad1143eed6dc532",  # TM Mirror
-        "aebcce6969f6c05658f124b4d13e0144acacd9cd1d258279fb634a96c10052a4",  # Public
-        "4be7beacd1d95e5dc42606dae7147c5d9b8804f0b54d4683cbf02cb2a3f8ff43",  # GitHub Actions
-    ],
+    hashes = [],
     version = "2019.11.28",
 )
 
 pip_library(
     name = "chardet",
-    hashes = [
-        "ac4bab4ffa21a25e617a083da655f4f3515616fcbc0623cecd30169d8ac17d51",  # TM Mirror
-        "e9c3ba2c73032fb5f59330d2e1514fa6a440effa6b5ebace917884b7875fdd72",  # Public
-        "be1489489a31e19f2665de886fd89f37cf4325b7740c9e5131afa69b054ab128",  # GitHub Actions
-    ],
+    hashes = [],
     version = "3.0.4",
 )
 
 pip_library(
     name = "idna",
-    hashes = [
-        "6777f28e7113d6e780e0bcdcd837cc97b2cd5bfedaf3b25b202e64ad1819d69d",  # TM Mirror
-        "9313e4342b41fa3eb7fa1cdc53392b392aa59b266e4a04edfc4a0edaaefd484d",  # Public
-        "44ca85ef74af1d787ccbb9d94031748b2a3839a60e38b5f700d042bfcc0de283",  # GitHub Actions
-    ],
+    hashes = []
     version = "2.9",
 )
 
 pip_library(
     name = "defectdojo_api",
-    hashes = [
-        "12686f665001eff963e4ab91e00086b84b4187c01dca742d2af00897e0124f19",  # Public
-        "0e984b75e15e221678465765964f8524d3d9f4c96010b66f0ec8a1964a827e3b",  # GitHub Actions
-    ],
+    hashes = [],
     licences = ["MIT"],
     version = "1.1.3",
     deps = [":requests"],


### PR DESCRIPTION
…ent hashes until we can switch to pypi's hosted wheels