### PR TITLE
Dracon producer to parse `yarn audit --json` jsonlines

### DIFF
--- a/producers/producer.go
+++ b/producers/producer.go
@@ -3,6 +3,7 @@
 package producers
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"flag"
@@ -53,12 +54,31 @@ func ParseFlags() error {
 	return nil
 }
 
+func ReadLines() ([][]byte, error) {
+	file, err := os.Open(InResults)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner((file))
+
+	var result [][]byte
+
+	for scanner.Scan() {
+		result = append(result, scanner.Bytes())
+	}
+
+	return result, nil
+}
+
 // ReadInFile returns the contents of the file given by InResults.
 func ReadInFile() ([]byte, error) {
 	file, err := os.Open(InResults)
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 
 	buffer := new(bytes.Buffer)
 	buffer.ReadFrom(file)

--- a/producers/producer.go
+++ b/producers/producer.go
@@ -54,6 +54,7 @@ func ParseFlags() error {
 	return nil
 }
 
+// ReadLines returns the lines of the contents of the file given by InResults
 func ReadLines() ([][]byte, error) {
 	file, err := os.Open(InResults)
 	if err != nil {

--- a/producers/producer.go
+++ b/producers/producer.go
@@ -61,7 +61,7 @@ func ReadLines() ([][]byte, error) {
 	}
 	defer file.Close()
 
-	scanner := bufio.NewScanner((file))
+	scanner := bufio.NewScanner(file)
 
 	var result [][]byte
 

--- a/producers/yarn_audit/BUILD
+++ b/producers/yarn_audit/BUILD
@@ -1,6 +1,6 @@
 subinclude("//third_party/defs:docker")
 
-# this producer covers nancy https://github.com/sonatype-nexus-community/nancy
+# this producer covers yarn audit https://classic.yarnpkg.com/lang/en/docs/cli/audit/
 
 go_binary(
     name = "yarn_audit",

--- a/producers/yarn_audit/BUILD
+++ b/producers/yarn_audit/BUILD
@@ -1,0 +1,24 @@
+subinclude("//third_party/defs:docker")
+
+# this producer covers nancy https://github.com/sonatype-nexus-community/nancy
+
+go_binary(
+    name = "yarn_audit",
+    srcs = [
+        "main.go",
+    ],
+    deps = [
+        "//api/proto:v1",
+        "//producers",
+        "//producers/yarn_audit/types",
+    ],
+)
+
+docker_image(
+    name = "dracon-producer-yarn-audit",
+    srcs = [
+        ":yarn_audit",
+    ],
+    base_image = "//build/docker:dracon-base-go",
+    image = "dracon-producer-yarn-audit",
+)

--- a/producers/yarn_audit/Dockerfile
+++ b/producers/yarn_audit/Dockerfile
@@ -1,0 +1,5 @@
+FROM //build/docker:dracon-base-go
+
+COPY nancy /parse
+
+ENTRYPOINT ["/parse"]

--- a/producers/yarn_audit/Dockerfile
+++ b/producers/yarn_audit/Dockerfile
@@ -1,5 +1,5 @@
 FROM //build/docker:dracon-base-go
 
-COPY nancy /parse
+COPY yarn_audit /parse
 
 ENTRYPOINT ["/parse"]

--- a/producers/yarn_audit/README.md
+++ b/producers/yarn_audit/README.md
@@ -1,0 +1,1 @@
+For use with output of `yarn audit --json`

--- a/producers/yarn_audit/main.go
+++ b/producers/yarn_audit/main.go
@@ -17,14 +17,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	report, err := types.NewReport(inLines)
+	report, errors := types.NewReport(inLines)
 
-	if len(err) > 0 {
-		errorMessage := "Errors creating Yarn Audit report: %s"
+	// Individual errors should already be printed to logs
+	if len(errors) > 0 {
+		errorMessage := "Errors creating Yarn Audit report: %d"
 		if report != nil{
-			log.Printf(errorMessage, err)
+			log.Printf(errorMessage, len(errors))
 		} else {
-			log.Fatalf(errorMessage, err)
+			log.Fatalf(errorMessage, len(errors))
 		}
 	}
 

--- a/producers/yarn_audit/main.go
+++ b/producers/yarn_audit/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/thought-machine/dracon/producers/yarn_audit/types"
+	"log"
+
+	"github.com/thought-machine/dracon/producers"
+)
+
+func main() {
+	if err := producers.ParseFlags(); err != nil {
+		log.Fatal(err)
+	}
+
+	inLines, err := producers.ReadLines()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	report, err := types.NewReport(inLines)
+
+	if len(err) > 0 {
+		errorMessage := "Errors creating Yarn Audit report: %s"
+		if report != nil{
+			log.Printf(errorMessage, err)
+		} else {
+			log.Fatalf(errorMessage, err)
+		}
+	}
+
+	if report != nil {
+		if err := producers.WriteDraconOut(
+			"yarn-audit",
+			report.AsIssues(),
+		); err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/producers/yarn_audit/main.go
+++ b/producers/yarn_audit/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/thought-machine/dracon/producers/yarn_audit/types"
-	"log"
-
 	"github.com/thought-machine/dracon/producers"
+	"github.com/thought-machine/dracon/producers/yarn_audit/types"
+
+	"log"
 )
 
 func main() {

--- a/producers/yarn_audit/types/BUILD
+++ b/producers/yarn_audit/types/BUILD
@@ -1,0 +1,24 @@
+go_library(
+    name = "types",
+    srcs = [
+        "yarn-issue.go",
+    ],
+    visibility = ["//producers/yarn_audit/..."],
+    deps = [
+        "//api/proto:v1",
+        "//producers",
+    ],
+)
+
+go_test(
+    name = "types_test",
+    srcs = [
+        "yarn-issue_test.go",
+    ],
+    deps = [
+        ":types",
+        "//api/proto:v1",
+        "//producers",
+        "//third_party/go:stretchr_testify",
+    ],
+)

--- a/producers/yarn_audit/types/yarn-issue.go
+++ b/producers/yarn_audit/types/yarn-issue.go
@@ -1,0 +1,221 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
+	"github.com/thought-machine/dracon/producers"
+
+	"log"
+)
+
+func yarnToIssueSeverity(severity string) v1.Severity {
+
+	switch severity {
+	case "low":
+		return v1.Severity_SEVERITY_LOW
+	case "moderate":
+		return v1.Severity_SEVERITY_MEDIUM
+	case "high":
+		return v1.Severity_SEVERITY_HIGH
+	case "critical":
+		return v1.Severity_SEVERITY_CRITICAL
+	default:
+		return v1.Severity_SEVERITY_INFO
+
+	}
+}
+
+type YarnAuditLine struct {
+	Type string      `json:"type"`
+	Data interface{} `json:"data"`
+}
+
+func (yl *YarnAuditLine) UnmarshalJSON(data []byte) error {
+	var typ struct {
+		Type string `json:"type"`
+	}
+
+	if err := json.Unmarshal(data, &typ); err != nil {
+		return err
+	}
+
+	switch typ.Type {
+	case "auditSummary":
+		yl.Data = new(SummaryData)
+	case "auditAdvisory":
+		yl.Data = new(AuditData)
+	case "auditAction":
+		yl.Data = new(AuditActionData)
+	default:
+		log.Printf("Parsed unsupported type: %s", typ.Type)
+	}
+
+	type tmp YarnAuditLine // avoids infinite recursion
+	return json.Unmarshal(data, (*tmp)(yl))
+
+}
+
+type AuditActionData struct {
+	Cmd        string      `json:"cmd"`
+	IsBreaking bool        `json:"isBreaking"`
+	Action     AuditAction `json:"action"`
+}
+
+type AuditData struct {
+	Resolution AuditResolution `json:"resolution"`
+	Advisory   Advisory        `json:"advisory"`
+}
+
+func (audit *AuditData) AsIssue() *v1.Issue {
+	var targetName string
+	if audit.Resolution.Path != "" {
+		targetName = audit.Resolution.Path + ": "
+	}
+	targetName += audit.Advisory.ModuleName
+
+	return &v1.Issue{
+		Target:      targetName,
+		Type:        audit.Advisory.Cwe,
+		Title:       audit.Advisory.Title,
+		Severity:    yarnToIssueSeverity(audit.Advisory.Severity),
+		Confidence:  v1.Confidence_CONFIDENCE_HIGH,
+		Description: fmt.Sprintf("%s", audit.Advisory.GetDescription()),
+		Cve:         strings.Join(audit.Advisory.Cves, ", "),
+	}
+}
+
+type SummaryData struct {
+	Vulnerabilities      Vulnerabilities `json:"vulnerabilities"`
+	Dependencies         int             `json:"dependencies"`
+	DevDependencies      int             `json:"devDependencies"`
+	OptionalDependencies int             `json:"optionalDependencies"`
+	TotalDependencies    int             `json:"totalDependencies"`
+}
+
+type AuditAction struct {
+	Action   string            `json:"action"`
+	Module   string            `json:"module"`
+	Target   string            `json:"target"`
+	IsMajor  bool              `json:"isMajor"`
+	Resolves []AuditResolution `json:"resolves"`
+}
+
+type Vulnerabilities struct {
+	Info     int `json:"info"`
+	Low      int `json:"low"`
+	Moderate int `json:"moderate"`
+	High     int `json:"high"`
+	Critical int `json:"critical"`
+}
+
+type Advisory struct {
+	Findings           []Finding         `json:"findings"`
+	Metadata           *AdvisoryMetaData `json:"metadata"`
+	VulnerableVersions string            `json:"vulnerable_versions"`
+	ModuleName         string            `json:"module_name"`
+	Severity           string            `json:"severity"`
+	GithubAdvisoryId   string            `json:"github_advisory_id"`
+	Cves               []string          `json:"cves"`
+	Access             string            `json:"access"`
+	PatchedVersions    string            `json:"patched_versions"`
+	Updated            string            `json:"updated"`
+	Recommendation     string            `json:"recommendation"`
+	Cwe                string            `json:"cwe"`
+	FoundBy            *Contact          `json:"found_by"`
+	Deleted            bool              `json:"deleted"`
+	Id                 int               `json:"id"`
+	References         string            `json:"references"`
+	Created            string            `json:"created"`
+	ReportedBy         *Contact          `json:"reported_by"`
+	Title              string            `json:"title"`
+	NpmAdvisoryId      interface{}       `json:"npm_advisory_id"`
+	Overview           string            `json:"overview"`
+	URL                string            `json:"url"`
+}
+
+func (advisory *Advisory) GetDescription() string {
+	return fmt.Sprintf(
+		"Vulnerable Versions: %s\nRecommendation: %s\nOverview: %s\nReferences:\n%s\nAdvisory URL: %s\n",
+		advisory.VulnerableVersions,
+		advisory.Recommendation,
+		advisory.Overview,
+		advisory.References,
+		advisory.URL,
+	)
+}
+
+type Finding struct {
+	Version  string   `json:"version"`
+	Paths    []string `json:"paths"`
+	Dev      bool     `json:"dev"`
+	Optional bool     `json:"optional"`
+	Bundled  bool     `json:"bundled"`
+}
+
+type AuditResolution struct {
+	Id       int    `json:"id"`
+	Path     string `json:"path"`
+	Dev      bool   `json:"dev"`
+	Optional bool   `json:"optional"`
+	Bundled  bool   `json:"bundled"`
+}
+
+type AdvisoryMetaData struct {
+	Module_type         string `json:"module_type"`
+	Exploitability      int    `json:"exploitability"`
+	Affected_components string `json:"affected_components"`
+}
+
+type Contact struct {
+	Name string `json: name`
+}
+
+type YarnAuditReport struct {
+	AuditAdvisory []*AuditData
+	AuditActions  []*AuditActionData
+	Summary       *SummaryData
+}
+
+func NewReport(reportLines [][]byte) (*YarnAuditReport, []error) {
+
+	var report YarnAuditReport
+
+	var errors []error
+
+	for _, line := range reportLines {
+		var auditLine YarnAuditLine
+		if err := producers.ParseJSON(line, &auditLine); err != nil {
+			log.Printf("Error parsing JSON line '%s': %s\n", line, err)
+			errors = append(errors, err)
+		} else {
+
+			switch auditLine.Data.(type) {
+			case *SummaryData:
+				report.Summary = auditLine.Data.(*SummaryData)
+			case *AuditData:
+				report.AuditAdvisory = append(report.AuditAdvisory, auditLine.Data.(*AuditData))
+			case *AuditActionData:
+				report.AuditActions = append(report.AuditActions, auditLine.Data.(*AuditActionData))
+			}
+		}
+	}
+
+	if len(report.AuditAdvisory) > 0 {
+		return &report, errors
+	}
+
+	return nil, errors
+}
+
+func (r *YarnAuditReport) AsIssues() []*v1.Issue {
+	issues := make([]*v1.Issue, 0)
+
+	for _, audit := range r.AuditAdvisory {
+		issues = append(issues, audit.AsIssue())
+	}
+
+	return issues
+}

--- a/producers/yarn_audit/types/yarn-issue_test.go
+++ b/producers/yarn_audit/types/yarn-issue_test.go
@@ -211,8 +211,8 @@ func TestParseValidReportSummary(t *testing.T) {
 
 	assert.NotNil(t, report.AuditSummary)
 
-	expectedSummaryData := AuditSummaryData{
-		Vulnerabilities: Vulnerabilities{
+	expectedSummaryData := auditSummaryData{
+		Vulnerabilities: vulnerabilities{
 			Info:     1,
 			Low:      10,
 			Moderate: 177,
@@ -238,17 +238,17 @@ func TestParseValidReportAdvisories(t *testing.T) {
 
 	assert.Len(t, report.AuditAdvisories, 2)
 
-	expectedAdvisories := []*AuditAdvisoryData{
+	expectedAdvisories := []*auditAdvisoryData{
 		{
-			Resolution: AuditResolution{
-				Id:       1004946,
+			Resolution: auditResolution{
+				ID:       1004946,
 				Path:     "advisory1Path",
 				Dev:      false,
 				Optional: false,
 				Bundled:  false,
 			},
-			Advisory: Advisory{
-				Findings: []Finding{
+			Advisory: yarnAdvisory{
+				Findings: []finding{
 					{
 						Version: "5.0.0",
 						Paths: []string{
@@ -267,7 +267,7 @@ func TestParseValidReportAdvisories(t *testing.T) {
 				VulnerableVersions: ">2.1.1 <5.0.1",
 				ModuleName:         "super-awesome-module",
 				Severity:           "moderate",
-				GithubAdvisoryId:   "GHSA-93q8-gq69-wqmw",
+				GithubAdvisoryID:   "GHSA-93q8-gq69-wqmw",
 				Cves: []string{
 					"CVE-2022-0001",
 				},
@@ -278,26 +278,26 @@ func TestParseValidReportAdvisories(t *testing.T) {
 				Cwe:             "CWE-918",
 				FoundBy:         nil,
 				Deleted:         false,
-				Id:              1004946,
+				ID:              1004946,
 				References:      "- https://advisory1.test.url/Ref1\n- https://advisory1.test.url/Ref2",
 				Created:         "2021-11-18T16:00:48.472Z",
 				ReportedBy:      nil,
 				Title:           "ADVISORY 1 TITLE",
-				NpmAdvisoryId:   nil,
+				NpmAdvisoryID:   nil,
 				Overview:        "Advisory 1 overview",
 				URL:             "https://advisory.1.url",
 			},
 		},
 		{
-			Resolution: AuditResolution{
-				Id:       1004947,
+			Resolution: auditResolution{
+				ID:       1004947,
 				Path:     "advisory2Path",
 				Dev:      true,
 				Optional: false,
 				Bundled:  false,
 			},
-			Advisory: Advisory{
-				Findings: []Finding{
+			Advisory: yarnAdvisory{
+				Findings: []finding{
 					{
 						Version: "1.1.0",
 						Paths: []string{
@@ -316,7 +316,7 @@ func TestParseValidReportAdvisories(t *testing.T) {
 				VulnerableVersions: ">1.1.1 <1.2.0",
 				ModuleName:         "not-so-awesome-module",
 				Severity:           "low",
-				GithubAdvisoryId:   "GHSA-93q8-gq69-wqmw",
+				GithubAdvisoryID:   "GHSA-93q8-gq69-wqmw",
 				Cves: []string{
 					"CVE-2022-0002",
 				},
@@ -327,12 +327,12 @@ func TestParseValidReportAdvisories(t *testing.T) {
 				Cwe:             "CWE-920",
 				FoundBy:         nil,
 				Deleted:         false,
-				Id:              1004947,
+				ID:              1004947,
 				References:      "- https://advisory2.test.url/Ref1\n- https://advisory2.test.url/Ref2\n- https://advisory2.test.url/Ref3",
 				Created:         "2021-11-18T16:00:48.472Z",
 				ReportedBy:      nil,
 				Title:           "ADVISORY 2 TITLE",
-				NpmAdvisoryId:   nil,
+				NpmAdvisoryID:   nil,
 				Overview:        "Advisory 2 overview",
 				URL:             "https://advisory.2.url",
 			},
@@ -352,17 +352,17 @@ func TestParseValidReportActions(t *testing.T) {
 
 	assert.Len(t, report.AuditActions, 1)
 
-	expectedActionData := AuditActionData{
+	expectedActionData := auditActionData{
 		Cmd:        "action command",
 		IsBreaking: false,
-		Action: AuditAction{
+		Action: auditAction{
 			Action:  "action string",
 			Module:  "action module string",
 			Target:  "action target",
 			IsMajor: true,
-			Resolves: []AuditResolution{
+			Resolves: []auditResolution{
 				{
-					Id:       1,
+					ID:       1,
 					Path:     "action reolve path",
 					Dev:      true,
 					Optional: true,

--- a/producers/yarn_audit/types/yarn-issue_test.go
+++ b/producers/yarn_audit/types/yarn-issue_test.go
@@ -196,8 +196,8 @@ func TestParseValidReportContainsAllSupportedFields(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, report)
 
-	assert.NotNil(t, report.Summary)
-	assert.Len(t, report.AuditAdvisory, 2)
+	assert.NotNil(t, report.AuditSummary)
+	assert.Len(t, report.AuditAdvisories, 2)
 	assert.Len(t, report.AuditActions, 1)
 }
 
@@ -209,9 +209,9 @@ func TestParseValidReportSummary(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, report)
 
-	assert.NotNil(t, report.Summary)
+	assert.NotNil(t, report.AuditSummary)
 
-	expectedSummaryData := SummaryData{
+	expectedSummaryData := AuditSummaryData{
 		Vulnerabilities: Vulnerabilities{
 			Info:     1,
 			Low:      10,
@@ -225,7 +225,7 @@ func TestParseValidReportSummary(t *testing.T) {
 		TotalDependencies:    6274,
 	}
 
-	assert.True(t, reflect.DeepEqual(&expectedSummaryData, report.Summary), report.Summary)
+	assert.True(t, reflect.DeepEqual(&expectedSummaryData, report.AuditSummary), report.AuditSummary)
 }
 
 func TestParseValidReportAdvisories(t *testing.T) {
@@ -236,9 +236,9 @@ func TestParseValidReportAdvisories(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, report)
 
-	assert.Len(t, report.AuditAdvisory, 2)
+	assert.Len(t, report.AuditAdvisories, 2)
 
-	expectedAdvisories := []*AuditData{
+	expectedAdvisories := []*AuditAdvisoryData{
 		{
 			Resolution: AuditResolution{
 				Id:       1004946,
@@ -339,7 +339,7 @@ func TestParseValidReportAdvisories(t *testing.T) {
 		},
 	}
 
-	assert.True(t, reflect.DeepEqual(expectedAdvisories, report.AuditAdvisory), report.AuditAdvisory)
+	assert.True(t, reflect.DeepEqual(expectedAdvisories, report.AuditAdvisories), report.AuditAdvisories)
 }
 
 func TestParseValidReportActions(t *testing.T) {
@@ -382,7 +382,7 @@ func TestParseValidReportAsIssues(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Len(t, report.AuditAdvisory, 2)
+	assert.Len(t, report.AuditAdvisories, 2)
 
 	issues := report.AsIssues()
 	assert.Len(t, issues, 2)

--- a/producers/yarn_audit/types/yarn-issue_test.go
+++ b/producers/yarn_audit/types/yarn-issue_test.go
@@ -1,0 +1,387 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "github.com/thought-machine/dracon/api/proto/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var invalidJSON = `Not a valid JSON object`
+
+func TestParseInvalidJSON(t *testing.T) {
+	oneLine := []byte(invalidJSON)
+	report, err := NewReport([][]byte{
+		oneLine,
+		oneLine,
+	})
+
+	assert.Nil(t, report)
+
+	assert.Len(t, err, 2)
+}
+
+// In reality these would be single lines, but for readability in test these should also work
+var fullYarnJSONLines [][]byte = [][]byte{
+	[]byte(`
+	{
+    "type": "auditAdvisory",
+    "data": {
+      "resolution": {
+        "id": 1004946,
+        "path": "advisory1Path",
+        "dev": false,
+        "optional": false,
+        "bundled": false
+      },
+      "advisory": {
+        "findings": [
+          {
+            "version": "5.0.0",
+            "paths": [
+              "some/path",
+              "another/path"
+            ]
+          },
+          {
+            "version": "5.0.0",
+            "paths": [
+              "more/findings/path"
+            ]
+          }
+        ],
+        "metadata": null,
+        "vulnerable_versions": ">2.1.1 <5.0.1",
+        "module_name": "super-awesome-module",
+        "severity": "moderate",
+        "github_advisory_id": "GHSA-93q8-gq69-wqmw",
+        "cves": [
+          "CVE-2022-0001"
+        ],
+        "access": "public",
+        "patched_versions": ">=5.0.1",
+        "updated": "2021-09-23T15:45:50.000Z",
+        "recommendation": "Upgrade to version 5.0.1 or later",
+        "cwe": "CWE-918",
+        "found_by": null,
+        "deleted": null,
+        "id": 1004946,
+        "references": "- https://advisory1.test.url/Ref1\n- https://advisory1.test.url/Ref2",
+        "created": "2021-11-18T16:00:48.472Z",
+        "reported_by": null,
+        "title": "ADVISORY 1 TITLE",
+        "npm_advisory_id": null,
+        "overview": "Advisory 1 overview",
+        "url": "https://advisory.1.url"
+      }
+    }
+  }`),
+	[]byte(`
+  {
+    "type": "auditAdvisory",
+    "data": {
+      "resolution": {
+        "id": 1004946,
+        "path": "advisory2Path",
+        "dev": false,
+        "optional": false,
+        "bundled": false
+      },
+      "advisory": {
+        "findings": [
+          {
+            "version": "5.0.0",
+            "paths": [
+              "some/path",
+              "another/path"
+            ]
+          },
+          {
+            "version": "5.0.0",
+            "paths": [
+              "more/findings/path"
+            ]
+          }
+        ],
+        "metadata": null,
+        "vulnerable_versions": ">1.1.1 <1.2.0",
+        "module_name": "not-so-awesome-module",
+        "severity": "moderate",
+        "github_advisory_id": "GHSA-93q8-gq69-wqmw",
+        "cves": [
+          "CVE-2022-0002"
+        ],
+        "access": "public",
+        "patched_versions": ">=1.2.0",
+        "updated": "2021-09-23T15:45:50.000Z",
+        "recommendation": "Upgrade to version 1.2.0 or later",
+        "cwe": "CWE-918",
+        "found_by": null,
+        "deleted": null,
+        "id": 1004946,
+        "references": "- https://advisory2.test.url/Ref1\n- https://advisory2.test.url/Ref2\n- https://advisory2.test.url/Ref3",
+        "created": "2021-11-18T16:00:48.472Z",
+        "reported_by": null,
+        "title": "ADVISORY 2 TITLE",
+        "npm_advisory_id": null,
+        "overview": "Advisory 2 overview",
+        "url": "https://advisory.2.url"
+      }
+    }
+  }`),
+	[]byte(`{
+    "type":"auditAction",
+    "data":{
+      "cmd":"action command",
+      "isBreaking":false,
+      "action":{
+        "action":"action string",
+        "module":"action module string",
+        "target":"action target",
+        "isMajor":true,
+        "resolves":[
+          {
+            "id":1,
+            "path":"action reolve path",
+            "dev":true,
+            "optional":true,
+            "bundled":true
+          }
+        ]
+      }
+    }
+  }`),
+	[]byte(`{
+    "type": "auditSummary",
+    "data": {
+      "vulnerabilities": {
+        "info": 1,
+        "low": 10,
+        "moderate": 177,
+        "high": 94,
+        "critical": 4
+      },
+      "dependencies": 6274,
+      "devDependencies": 0,
+      "optionalDependencies": 0,
+      "totalDependencies": 6274
+    }
+  }`),
+	[]byte(`{
+    "type": "unsupported",
+    "data": {
+      "vulnerabilities": {
+        "info": 1,
+        "low": 10,
+        "moderate": 177,
+        "high": 94,
+        "critical": 4
+      },
+      "dependencies": 6274,
+      "devDependencies": 0,
+      "optionalDependencies": 0,
+      "totalDependencies": 6274
+    }
+  }`),
+	[]byte(`{
+    "completely": "unsupported"
+  }`),
+}
+
+func TestParseValidReportContainsAllFields(t *testing.T) {
+	report, err := NewReport(
+		fullYarnJSONLines,
+	)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, report)
+
+	assert.NotNil(t, report.Summary)
+	assert.Len(t, report.AuditAdvisory, 2)
+	assert.Len(t, report.AuditActions, 1)
+}
+
+func TestParseValidReportSummary(t *testing.T) {
+	report, err := NewReport(
+		fullYarnJSONLines,
+	)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, report)
+
+	assert.NotNil(t, report.Summary)
+
+	expectedSummaryData := SummaryData{
+		Vulnerabilities: Vulnerabilities{
+			Info:     1,
+			Low:      10,
+			Moderate: 177,
+			High:     94,
+			Critical: 4,
+		},
+		Dependencies:         6274,
+		DevDependencies:      0,
+		OptionalDependencies: 0,
+		TotalDependencies:    6274,
+	}
+
+	assert.True(t, reflect.DeepEqual(&expectedSummaryData, report.Summary), report.Summary)
+}
+
+func TestParseValidReportAdvisories(t *testing.T) {
+	report, err := NewReport(
+		fullYarnJSONLines,
+	)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, report)
+
+	assert.Len(t, report.AuditAdvisory, 2)
+
+	expectedFirstAdvisory := AuditData{
+		Resolution: AuditResolution{
+			Id:       1004946,
+			Path:     "advisory1Path",
+			Dev:      false,
+			Optional: false,
+			Bundled:  false,
+		},
+		Advisory: Advisory{
+			Findings: []Finding{
+				{
+					Version: "5.0.0",
+					Paths: []string{
+						"some/path",
+						"another/path",
+					},
+				},
+				{
+					Version: "5.0.0",
+					Paths: []string{
+						"more/findings/path",
+					},
+				},
+			},
+			Metadata:           nil,
+			VulnerableVersions: ">2.1.1 <5.0.1",
+			ModuleName:         "super-awesome-module",
+			Severity:           "moderate",
+			GithubAdvisoryId:   "GHSA-93q8-gq69-wqmw",
+			Cves: []string{
+				"CVE-2022-0001",
+			},
+			Access:          "public",
+			PatchedVersions: ">=5.0.1",
+			Updated:         "2021-09-23T15:45:50.000Z",
+			Recommendation:  "Upgrade to version 5.0.1 or later",
+			Cwe:             "CWE-918",
+			FoundBy:         nil,
+			Deleted:         false,
+			Id:              1004946,
+			References:      "- https://advisory1.test.url/Ref1\n- https://advisory1.test.url/Ref2",
+			Created:         "2021-11-18T16:00:48.472Z",
+			ReportedBy:      nil,
+			Title:           "ADVISORY 1 TITLE",
+			NpmAdvisoryId:   nil,
+			Overview:        "Advisory 1 overview",
+			URL:             "https://advisory.1.url",
+		},
+	}
+
+	assert.True(t, reflect.DeepEqual(&expectedFirstAdvisory, report.AuditAdvisory[0]), report.AuditAdvisory[0])
+}
+
+func TestParseValidReportActions(t *testing.T) {
+	report, err := NewReport(
+		fullYarnJSONLines,
+	)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, report)
+
+	assert.Len(t, report.AuditActions, 1)
+
+	expectedActionData := AuditActionData{
+		Cmd:        "action command",
+		IsBreaking: false,
+		Action: AuditAction{
+			Action:  "action string",
+			Module:  "action module string",
+			Target:  "action target",
+			IsMajor: true,
+			Resolves: []AuditResolution{
+				{
+					Id:       1,
+					Path:     "action reolve path",
+					Dev:      true,
+					Optional: true,
+					Bundled:  true,
+				},
+			},
+		},
+	}
+
+	assert.True(t, reflect.DeepEqual(&expectedActionData, report.AuditActions[0]), report.AuditActions[0])
+}
+
+func TestParseValidReportAsIssues(t *testing.T) {
+	report, err := NewReport(
+		fullYarnJSONLines,
+	)
+
+	assert.Nil(t, err)
+
+	assert.Len(t, report.AuditAdvisory, 2)
+
+	issues := report.AsIssues()
+	assert.Len(t, issues, 2)
+
+	expectedIssues := []*v1.Issue{
+		&v1.Issue{
+			Target:     "advisory1Path: super-awesome-module",
+			Type:       "CWE-918",
+			Title:      "ADVISORY 1 TITLE",
+			Severity:   v1.Severity_SEVERITY_MEDIUM,
+			Confidence: v1.Confidence_CONFIDENCE_HIGH,
+			Description: `Vulnerable Versions: >2.1.1 <5.0.1
+Recommendation: Upgrade to version 5.0.1 or later
+Overview: Advisory 1 overview
+References:
+- https://advisory1.test.url/Ref1
+- https://advisory1.test.url/Ref2
+Advisory URL: https://advisory.1.url
+`,
+			Cve: "CVE-2022-0001",
+		},
+		&v1.Issue{
+			Target:     "advisory2Path: not-so-awesome-module",
+			Type:       "CWE-918",
+			Title:      "ADVISORY 2 TITLE",
+			Severity:   v1.Severity_SEVERITY_MEDIUM,
+			Confidence: v1.Confidence_CONFIDENCE_HIGH,
+			Description: `Vulnerable Versions: >1.1.1 <1.2.0
+Recommendation: Upgrade to version 1.2.0 or later
+Overview: Advisory 2 overview
+References:
+- https://advisory2.test.url/Ref1
+- https://advisory2.test.url/Ref2
+- https://advisory2.test.url/Ref3
+Advisory URL: https://advisory.2.url
+`,
+			Cve: "CVE-2022-0002",
+		},
+	}
+
+	for i := range expectedIssues {
+		assert.Equal(t, expectedIssues[i].Target, issues[i].Target)
+		assert.Equal(t, expectedIssues[i].Type, issues[i].Type)
+		assert.Equal(t, expectedIssues[i].Title, issues[i].Title)
+		assert.Equal(t, expectedIssues[i].Severity, issues[i].Severity)
+		assert.Equal(t, expectedIssues[i].Cvss, issues[i].Cvss)
+		assert.Equal(t, expectedIssues[i].Confidence, issues[i].Confidence)
+		assert.Equal(t, expectedIssues[i].Description, issues[i].Description)
+		assert.Equal(t, expectedIssues[i].Cve, issues[i].Cve)
+	}
+}


### PR DESCRIPTION
- Add support for reading lines in producer.go
- Each json line if of the form `{"type": "....", "data": "...."}`, where the shape of the value for `data` is dependendent on value for `type`
- This adds a `YarnAuditReport` `struct` in `yarn-issues.go` that includes
  - `AuditSummary` - the `data` field from the json line with `"type": "auditSummary"`
  - `AuditActions` - the list of `data` fields from json lines with `"type": "auditAction"`
  - `AuditAdvisories` - the list of `data` field from json lines with `"type": "auditAdvisory"`
  - `AsIssues()` function that returns a the list of `v1.Issues` used by Dracon. This only uses the `AuditAdvisories` field of the report for now.