### PR TITLE
Bump tekton version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kubernetes: ["1.20", "1.21", "1.22"]
+        kubernetes: ["1.21"]
     steps:
       - name: Install python dependencies
         run: sudo apt-get update && sudo apt-get install -y python3-setuptools python3-pip

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kubernetes: ["1.16", "1.17", "1.18"]
+        kubernetes: ["1.20", "1.21", "1.22"]
     steps:
       - name: Install python dependencies
         run: sudo apt-get update && sudo apt-get install -y python3-setuptools python3-pip

--- a/scripts/development/kind/setup.sh
+++ b/scripts/development/kind/setup.sh
@@ -11,9 +11,9 @@ kubernetes_version="${FLAGS_kubernetes_version//./_}"
 
 declare -A KUBERNETES_VERSIONS
 KUBERNETES_VERSIONS=(
-  ["1_20"]="kindest/node:v1.20.15@sha256:2d93744654696ea4270c04ec83e7940177295aac99223b224b052c79d4e7693e"
-  ["1_21"]="kindest/node:v1.21.10@sha256:f35554e42a1081cfc9f7bce5635aea15996e4ec842b689e1508a8746de7d309b"
-  ["1_22"]="kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9eb8bad68fa21709162aabf2b84e4a3896db05c0808"
+  ["1_20"]="kindest/node:v1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb"
+  ["1_21"]="kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c"
+  ["1_22"]="kindest/node:v1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166"
 )
 
 kubernetes_context="kind-${FLAGS_kind_cluster}"

--- a/scripts/development/kind/setup.sh
+++ b/scripts/development/kind/setup.sh
@@ -11,9 +11,7 @@ kubernetes_version="${FLAGS_kubernetes_version//./_}"
 
 declare -A KUBERNETES_VERSIONS
 KUBERNETES_VERSIONS=(
-  ["1_20"]="kindest/node:v1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb"
   ["1_21"]="kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c"
-  ["1_22"]="kindest/node:v1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166"
 )
 
 kubernetes_context="kind-${FLAGS_kind_cluster}"

--- a/scripts/development/kind/setup.sh
+++ b/scripts/development/kind/setup.sh
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 
 DEFINE_string 'kind_cluster' 'dracon' 'Kind cluster to use' 'c'
-DEFINE_string 'kubernetes_version' '1.17' 'Kubernetes version to use' 'k'
+DEFINE_string 'kubernetes_version' '1.21' 'Kubernetes version to use' 'k'
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
 
@@ -11,9 +11,9 @@ kubernetes_version="${FLAGS_kubernetes_version//./_}"
 
 declare -A KUBERNETES_VERSIONS
 KUBERNETES_VERSIONS=(
-  ["1_16"]="kindest/node:v1.16.15@sha256:83067ed51bf2a3395b24687094e283a7c7c865ccc12a8b1d7aa673ba0c5e8861"
-  ["1_17"]="kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00"
-  ["1_18"]="kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c"
+  ["1_20"]="kindest/node:v1.20.15@sha256:2d93744654696ea4270c04ec83e7940177295aac99223b224b052c79d4e7693e"
+  ["1_21"]="kindest/node:v1.21.10@sha256:f35554e42a1081cfc9f7bce5635aea15996e4ec842b689e1508a8746de7d309b"
+  ["1_22"]="kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9eb8bad68fa21709162aabf2b84e4a3896db05c0808"
 )
 
 kubernetes_context="kind-${FLAGS_kind_cluster}"

--- a/third_party/k8s/BUILD
+++ b/third_party/k8s/BUILD
@@ -16,20 +16,20 @@ remote_file(
     visibility = ["//scripts/development/kind/..."],
 )
 
-TEKTONCD_PIPELINE_VERSION = "0.19.0"
+TEKTONCD_PIPELINE_VERSION = "0.34.1"
 
 remote_file(
     name = "tektoncd_pipeline",
-    hashes = ["a6a9049595137ec95cd50f8c0767a01cf54e941f7b2381710596f1bc4f8db29b"],
+    hashes = ["9b12e7ed10e38aba742c22b49148fdccf806a985bf94de5c4c9857dd31e5ba75"],
     url = f"https://github.com/tektoncd/pipeline/releases/download/v{TEKTONCD_PIPELINE_VERSION}/release.yaml",
     visibility = ["//scripts/development/..."],
 )
 
-TEKTONCD_DASHBOARD_VERSION = "0.14.0"
+TEKTONCD_DASHBOARD_VERSION = "0.25.0"
 
 remote_file(
     name = "tektoncd_dashboard",
-    hashes = ["938edf9e16fdc91585a944b8f50182638fd5b653ac1311bfac73be768e2a730c"],
+    hashes = ["955a4e3afbdbaa3b67577154d5bf022888629ff3ea70d99197c0c1c6b529e056"],
     url = f"https://github.com/tektoncd/dashboard/releases/download/v{TEKTONCD_DASHBOARD_VERSION}/tekton-dashboard-release-readonly.yaml",
     visibility = ["//scripts/development/..."],
 )

--- a/third_party/tools/BUILD
+++ b/third_party/tools/BUILD
@@ -1,10 +1,10 @@
-KIND_VERSION = "0.11.1"
+KIND_VERSION = "0.12.0"
 
 remote_file(
     name = "kind",
     binary = True,
     hashes = [
-        "949f81b3c30ca03a3d4effdecda04f100fa3edc07a28b19400f72ede7c5f0491",  # linux-amd64
+        "b80624c14c807490c0944d21fdc9c3455d6cc904fad486fe236f2187ecaa5789",  # linux-amd64
     ],
     url = f"https://github.com/kubernetes-sigs/kind/releases/download/v{KIND_VERSION}/kind-{CONFIG.OS}-{CONFIG.ARCH}",
     visibility = ["//scripts/..."],


### PR DESCRIPTION
This bumps the pipeline version to 0.34.1 and the dashboard version to 0.25.0. Unfortunately the latter does not support the latest pipeline version (0.35.0), which is why we are using the one before.