### PR TITLE
Support Elasticsearch 8

### DIFF
--- a/consumers/elasticsearch/BUILD
+++ b/consumers/elasticsearch/BUILD
@@ -1,7 +1,7 @@
 subinclude("//third_party/defs:docker")
 
 go_binary(
-    name = "elasticsearch_c",
+    name = "elasticsearch",
     srcs = [
         "main.go",
     ],
@@ -9,13 +9,13 @@ go_binary(
     deps = [
         "//api/proto:v1",
         "//consumers",
-        "//third_party/go:elastic_go-elasticsearch_v7",
+        "//third_party/go:elastic_go-elasticsearch_v8",
         "//third_party/go:protobuf",
     ],
 )
 
 go_test(
-    name = "elasticsearch_c_test",
+    name = "elasticsearch_test",
     srcs = [
         "main.go",
         "main_test.go",
@@ -23,7 +23,7 @@ go_test(
     deps = [
         "//api/proto:v1",
         "//consumers",
-        "//third_party/go:elastic_go-elasticsearch_v7",
+        "//third_party/go:elastic_go-elasticsearch_v8",
         "//third_party/go:gogo_protobuf",
         "//third_party/go:protobuf",
         "//third_party/go:stretchr_testify",
@@ -33,7 +33,7 @@ go_test(
 docker_image(
     name = "dracon-consumer-elasticsearch",
     srcs = [
-        ":elasticsearch_c",
+        ":elasticsearch",
     ],
     base_image = "//build/docker:dracon-base-go",
     image = "dracon-consumer-elasticsearch",

--- a/consumers/elasticsearch/Dockerfile
+++ b/consumers/elasticsearch/Dockerfile
@@ -1,5 +1,5 @@
 FROM //build/docker:dracon-base-go
 
-COPY elasticsearch_c /consume
+COPY elasticsearch /consume
 
 ENTRYPOINT ["/consume"]

--- a/examples/pipelines/golang-project/BUILD
+++ b/examples/pipelines/golang-project/BUILD
@@ -12,7 +12,7 @@ kustomized_config(
         "pipeline-run.yaml",
     ],
     images = [
-        "//consumers/elasticsearch_c:dracon-consumer-elasticsearch",
+        "//consumers/elasticsearch:dracon-consumer-elasticsearch",
         "//cmd/enricher:dracon-enricher",
         "//source/git:dracon-source-git",
         "//producers/golang_gosec:dracon-producer-gosec",

--- a/examples/pipelines/golang-project/elasticsearch-consumer.yaml
+++ b/examples/pipelines/golang-project/elasticsearch-consumer.yaml
@@ -10,11 +10,10 @@ spec:
   # run elasticsearch consumer
   - name: run-elasticsearch-consumer
     image: index.docker.io/thoughtmachine/dracon-consumer-elasticsearch:latest
-    env: [
-      {name: ELASTICSEARCH_URL, value: http://elasticsearch.dracon.svc:9200}
-    ]
+    env: []
     command: ["/consume"]
     args: [
       "-in", "{{.ConsumerSourcePath}}",
+      "-es-urls", "http://elasticsearch.dracon.svc:9200",
       "-es-index", "dracon"
     ]

--- a/examples/pipelines/mixed-lang-project/BUILD
+++ b/examples/pipelines/mixed-lang-project/BUILD
@@ -14,7 +14,7 @@ kustomized_config(
         "spotbugs-producer.yaml",
     ],
     images = [
-        "//consumers/elasticsearch_c:dracon-consumer-elasticsearch",
+        "//consumers/elasticsearch:dracon-consumer-elasticsearch",
         "//cmd/enricher:dracon-enricher",
         "//source/git:dracon-source-git",
         "//producers/golang_gosec:dracon-producer-gosec",

--- a/examples/pipelines/mixed-lang-project/elasticsearch-consumer.yaml
+++ b/examples/pipelines/mixed-lang-project/elasticsearch-consumer.yaml
@@ -10,11 +10,10 @@ spec:
   # run elasticsearch consumer
   - name: run-elasticsearch-consumer
     image: index.docker.io/thoughtmachine/dracon-consumer-elasticsearch:latest
-    env: [
-      {name: ELASTICSEARCH_URL, value: http://elasticsearch.dracon.svc:9200}
-    ]
+    env: []
     command: ["/consume"]
     args: [
       "-in", "{{.ConsumerSourcePath}}",
+      "-es-urls", "http://elasticsearch.dracon.svc:9200",
       "-es-index", "dracon"
     ]

--- a/examples/pipelines/python-project/BUILD
+++ b/examples/pipelines/python-project/BUILD
@@ -12,7 +12,7 @@ kustomized_config(
         "pipeline-run.yaml",
     ],
     images = [
-        "//consumers/elasticsearch_c:dracon-consumer-elasticsearch",
+        "//consumers/elasticsearch:dracon-consumer-elasticsearch",
         "//cmd/enricher:dracon-enricher",
         "//source/git:dracon-source-git",
         "//producers/python_bandit:dracon-producer-bandit",

--- a/examples/pipelines/python-project/elasticsearch-consumer.yaml
+++ b/examples/pipelines/python-project/elasticsearch-consumer.yaml
@@ -11,11 +11,10 @@ spec:
   - name: run-elasticsearch-consumer
     image: index.docker.io/thoughtmachine/dracon-consumer-elasticsearch:latest
     imagePullPolicy: Never
-    env: [
-      {name: ELASTICSEARCH_URL, value: http://elasticsearch.dracon.svc:9200}
-    ]
+    env: []
     command: ["/consume"]
     args: [
       "-in", "{{.ConsumerSourcePath}}",
+      "-es-urls", "http://elasticsearch.dracon.svc:9200",
       "-es-index", "dracon"
     ]

--- a/scripts/development/k8s/elasticsearch-kibana/elasticsearch.yaml
+++ b/scripts/development/k8s/elasticsearch-kibana/elasticsearch.yaml
@@ -20,6 +20,8 @@ spec:
           env:
             - name: discovery.type
               value: single-node
+            - name: xpack.security.enabled
+              value: "false"
           ports:
             - containerPort: 9200
               name: client

--- a/scripts/development/k8s/elasticsearch-kibana/elasticsearch.yaml
+++ b/scripts/development/k8s/elasticsearch-kibana/elasticsearch.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: elasticsearch
-          image: docker.elastic.co/elasticsearch/elasticsearch:7.6.0
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.2.3
           env:
             - name: discovery.type
               value: single-node

--- a/scripts/development/k8s/elasticsearch-kibana/kibana.yaml
+++ b/scripts/development/k8s/elasticsearch-kibana/kibana.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: kibana
-          image: docker.elastic.co/kibana/kibana:7.6.0
+          image: docker.elastic.co/kibana/kibana:8.2.3
           ports:
             - containerPort: 5601
               name: webinterface

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -3,11 +3,11 @@ package(default_visibility = ["PUBLIC"])
 go_module(
     name = "elastic_go-elasticsearch_v8",
     hashes = ["7b3982f8aedf1ff8eff63afdd960916b15cf88464ac1c1e06f1a0f5b7b7add97"],
-     install = [
-         ".",
-         "esapi",
-         "internal/version",
-     ],
+    install = [
+        ".",
+        "esapi",
+        "internal/version",
+    ],
     module = "github.com/elastic/go-elasticsearch/v8",
     version = "v8.3.0",
     deps = [

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1,25 +1,29 @@
 package(default_visibility = ["PUBLIC"])
 
-# TODO(hjenkins): support ES 5 in ES consumer
 go_module(
-    name = "elastic_go-elasticsearch_v5",
-    hashes = ["41840bb5dbdd99ead7037d2f55633e9616202d1e58696f0c1d6c8cc22a569a20"],
-    module = "github.com/elastic/go-elasticsearch/v5",
-    version = "v5.6.1",
+    name = "elastic_go-elasticsearch_v8",
+    hashes = ["7b3982f8aedf1ff8eff63afdd960916b15cf88464ac1c1e06f1a0f5b7b7add97"],
+     install = [
+         ".",
+         "esapi",
+         "internal/version",
+     ],
+    module = "github.com/elastic/go-elasticsearch/v8",
+    version = "v8.3.0",
+    deps = [
+        ":elastic-transport_v8",
+    ],
 )
 
-# TODO(hjenkins): support ES 6 in ES consumer
 go_module(
-    name = "elastic_go-elasticsearch_v6",
-    hashes = ["e4691676db41046d251321bd12b88d86ecdab869a17d96374fd4eb633dddc400"],
+    name = "elastic-transport_v8",
+    hashes = ["5bff3ce3a964eab1b8a1c4f1175ccc96776fbfe2843e02fab369d2dbe8d025f7"],
     install = [
-        ".",
-        "esapi",
-        "estransport",
-        "internal/version",
+        "elastictransport",
+        "elastictransport/version",
     ],
-    module = "github.com/elastic/go-elasticsearch/v6",
-    version = "v6.8.2",
+    module = "github.com/elastic/elastic-transport-go/v8",
+    version = "v8.1.0",
 )
 
 go_module(
@@ -74,19 +78,6 @@ go_module(
     licences = ["BSD 3-Clause"],
     module = "github.com/trivago/tgo",
     version = "v1.0.7",
-)
-
-go_module(
-    name = "elastic_go-elasticsearch_v7",
-    hashes = ["943a5660abb1d2d08b47e9f3951d86667ca47c6ab2e85fd983cdd69673ccb541"],
-    install = [
-        ".",
-        "esapi",
-        "estransport",
-        "internal/version",
-    ],
-    module = "github.com/elastic/go-elasticsearch/v7",
-    version = "v7.6.0",
 )
 
 go_module(


### PR DESCRIPTION
- Switch to supporting ESv8
- Remove code that pretends to support more than the single ES version
- Rename elasticsearch_c -> elasticsearch to tidy up the name
- Allow passing of ES cluster urls via flags (as well as existing env variable)