### PR TITLE
Rewrite yarn-audit producer

### DIFF
--- a/producers/yarn_audit/README.md
+++ b/producers/yarn_audit/README.md
@@ -1,1 +1,1 @@
-For use with output of `yarn audit --json`
+For use with output of `yarn audit --json | jq -cs .`

--- a/producers/yarn_audit/main.go
+++ b/producers/yarn_audit/main.go
@@ -17,15 +17,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	_, auditAdvisories, _, err := types.NewReport(in)
+	yarnReport, err := types.NewReport(in)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if auditAdvisories != nil {
+	if yarnReport.AuditAdvisories != nil {
 		if err := producers.WriteDraconOut(
 			"yarn-audit",
-			types.AsIssues(auditAdvisories),
+			yarnReport.AuditAdvisories.AsIssues(),
 		); err != nil {
 			log.Fatal(err)
 		}

--- a/producers/yarn_audit/main.go
+++ b/producers/yarn_audit/main.go
@@ -12,27 +12,20 @@ func main() {
 		log.Fatal(err)
 	}
 
-	inLines, err := producers.ReadLines()
+	in, err := producers.ReadInFile()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	report, errors := types.NewReport(inLines)
-
-	// Individual errors should already be printed to logs
-	if len(errors) > 0 {
-		errorMessage := "Errors creating Yarn Audit report: %d"
-		if report != nil{
-			log.Printf(errorMessage, len(errors))
-		} else {
-			log.Fatalf(errorMessage, len(errors))
-		}
+	_, auditAdvisories, _, err := types.NewReport(in)
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	if report != nil {
+	if auditAdvisories != nil {
 		if err := producers.WriteDraconOut(
 			"yarn-audit",
-			report.AsIssues(),
+			types.AsIssues(auditAdvisories),
 		); err != nil {
 			log.Fatal(err)
 		}

--- a/producers/yarn_audit/types/yarn-issue.go
+++ b/producers/yarn_audit/types/yarn-issue.go
@@ -202,22 +202,13 @@ func (audit *auditAdvisoryData) AsIssue() *v1.Issue {
 	}
 	targetName += audit.Advisory.ModuleName
 
-	// yarn audit now outputs CWEs as an array. if there is at least one CWE use a comma-separated list,
-	// else use empty string
-	cweType := ""
-	if(len(audit.Advisory.Cwe) > 0) {
-		cweType = audit.Advisory.Cwe[0]
-
-		if (len(audit.Advisory.Cwe) > 1) {
-			for _, cwe := range audit.Advisory.Cwe {
-				cweType += fmt.Sprintf(", %s", cwe)
-			}
-		}
-	}
+	// yarn audit now outputs CWEs as an array. if there is at least one CWE provide a comma-separated list
+	// to issue constructor, else provide empty string
+	cwe := strings.Join(audit.Advisory.Cwe, ", ")
 
 	return &v1.Issue{
 		Target:      targetName,
-		Type:        cweType,
+		Type:        cwe,
 		Title:       audit.Advisory.Title,
 		Severity:    yarnToIssueSeverity(audit.Advisory.Severity),
 		Confidence:  v1.Confidence_CONFIDENCE_HIGH,

--- a/producers/yarn_audit/types/yarn-issue.go
+++ b/producers/yarn_audit/types/yarn-issue.go
@@ -25,13 +25,16 @@ func yarnToIssueSeverity(severity string) v1.Severity {
 	}
 }
 
+// AuditAction represents the action type within yarn audit output
 type AuditAction struct {
-	Type string 			`json:"type"`
-	Data auditActionData	`json:"data"`
+	Type string          `json:"type"`
+	Data auditActionData `json:"data"`
 }
 
+// AuditActions is a slice of AuditAction type
 type AuditActions []AuditAction
 
+// AuditAction.Unmarshal attempts to unmarshal a raw JSON message into the AuditAction struct
 func (audit *AuditAction) Unmarshal(raw json.RawMessage) bool {
 	if err := json.Unmarshal(raw, audit); err != nil {
 		return false
@@ -39,13 +42,16 @@ func (audit *AuditAction) Unmarshal(raw json.RawMessage) bool {
 	return audit.Type == "auditAction"
 }
 
+// AuditAdvisory represents the advisory type within yarn audit output
 type AuditAdvisory struct {
-	Type string 			`json:"type"`
-	Data auditAdvisoryData 	`json:"data"`
+	Type string            `json:"type"`
+	Data auditAdvisoryData `json:"data"`
 }
 
+// AuditAdvisories is a slice of AuditAdvisory type
 type AuditAdvisories []AuditAdvisory
 
+// AuditAdvisory.Unmarshal attempts to unmarshal a raw JSON message into the AuditAdvisory struct
 func (audit *AuditAdvisory) Unmarshal(raw json.RawMessage) bool {
 	if err := json.Unmarshal(raw, audit); err != nil {
 		return false
@@ -53,13 +59,16 @@ func (audit *AuditAdvisory) Unmarshal(raw json.RawMessage) bool {
 	return audit.Type == "auditAdvisory"
 }
 
+// AuditSummary represents the summary type within yarn audit output
 type AuditSummary struct {
-	Type string 			`json:"type"`
-	Data auditSummaryData 	`json:"data"`
+	Type string           `json:"type"`
+	Data auditSummaryData `json:"data"`
 }
 
+// AuditSummaries is a slice of AuditSummary type
 type AuditSummaries []AuditSummary
 
+// AuditSummary.Unmarshal attempts to unmarshal a raw JSON message into the AuditSummary struct
 func (audit *AuditSummary) Unmarshal(raw json.RawMessage) bool {
 	if err := json.Unmarshal(raw, audit); err != nil {
 		return false
@@ -68,9 +77,9 @@ func (audit *AuditSummary) Unmarshal(raw json.RawMessage) bool {
 }
 
 type auditActionData struct {
-	Cmd        string      			`json:"cmd"`
-	IsBreaking bool        			`json:"isBreaking"`
-	Action     auditActionAction 	`json:"action"`
+	Cmd        string            `json:"cmd"`
+	IsBreaking bool              `json:"isBreaking"`
+	Action     auditActionAction `json:"action"`
 }
 
 type auditAdvisoryData struct {
@@ -112,12 +121,12 @@ type yarnAdvisory struct {
 	Cves               []string          `json:"cves"`
 	Access             string            `json:"access"`
 	PatchedVersions    string            `json:"patched_versions"`
-	Cvss			   cvss				 `json:"cvss"`
+	Cvss               cvss              `json:"cvss"`
 	Updated            string            `json:"updated"`
 	Recommendation     string            `json:"recommendation"`
 	Cwe                []string          `json:"cwe"`
 	FoundBy            *contact          `json:"found_by"`
-	Deleted            bool          	 `json:"deleted"`
+	Deleted            bool              `json:"deleted"`
 	ID                 int               `json:"id"`
 	References         string            `json:"references"`
 	Created            string            `json:"created"`
@@ -129,8 +138,8 @@ type yarnAdvisory struct {
 }
 
 type cvss struct {
-	Score 		 json.Number `json:"score"`
-	VectorString string 	 `json:"vectorString"`
+	Score        json.Number `json:"score"`
+	VectorString string      `json:"vectorString"`
 }
 
 type finding struct {
@@ -151,7 +160,7 @@ type auditResolution struct {
 
 type advisoryMetaData struct {
 	ModuleType         string `json:"module_type"`
-	Exploitability      int   `json:"exploitability"`
+	Exploitability     int    `json:"exploitability"`
 	AffectedComponents string `json:"affected_components"`
 }
 
@@ -159,12 +168,14 @@ type contact struct {
 	Name string `json: name`
 }
 
+// YarnReport holds the actions/advisories/summaries from yarn audit input JSON
 type YarnReport struct {
 	AuditActions    AuditActions
 	AuditAdvisories AuditAdvisories
 	AuditSummaries  AuditSummaries
 }
 
+// NewReport transforms input yarn audit JSON into a YarnReport
 func NewReport(report []byte) (YarnReport, error) {
 	var raws []json.RawMessage
 	if err := json.Unmarshal(report, &raws); err != nil {

--- a/producers/yarn_audit/types/yarn-issue.go
+++ b/producers/yarn_audit/types/yarn-issue.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -34,7 +33,7 @@ type AuditAction struct {
 // AuditActions is a slice of AuditAction type
 type AuditActions []AuditAction
 
-// AuditAction.Unmarshal attempts to unmarshal a raw JSON message into the AuditAction struct
+// Unmarshal attempts to unmarshal a raw JSON message into the AuditAction struct
 func (audit *AuditAction) Unmarshal(raw json.RawMessage) bool {
 	if err := json.Unmarshal(raw, audit); err != nil {
 		return false
@@ -51,7 +50,7 @@ type AuditAdvisory struct {
 // AuditAdvisories is a slice of AuditAdvisory type
 type AuditAdvisories []AuditAdvisory
 
-// AuditAdvisory.Unmarshal attempts to unmarshal a raw JSON message into the AuditAdvisory struct
+// Unmarshal attempts to unmarshal a raw JSON message into the AuditAdvisory struct
 func (audit *AuditAdvisory) Unmarshal(raw json.RawMessage) bool {
 	if err := json.Unmarshal(raw, audit); err != nil {
 		return false
@@ -68,7 +67,7 @@ type AuditSummary struct {
 // AuditSummaries is a slice of AuditSummary type
 type AuditSummaries []AuditSummary
 
-// AuditSummary.Unmarshal attempts to unmarshal a raw JSON message into the AuditSummary struct
+// Unmarshal attempts to unmarshal a raw JSON message into the AuditSummary struct
 func (audit *AuditSummary) Unmarshal(raw json.RawMessage) bool {
 	if err := json.Unmarshal(raw, audit); err != nil {
 		return false
@@ -178,38 +177,34 @@ type YarnReport struct {
 // NewReport transforms input yarn audit JSON into a YarnReport
 func NewReport(report []byte) (YarnReport, error) {
 	var raws []json.RawMessage
+	yarnReport := YarnReport{}
+
 	if err := json.Unmarshal(report, &raws); err != nil {
 		return YarnReport{}, err
 	}
 
-	var auditActions AuditActions
-	var auditAdvisories AuditAdvisories
-	var auditSummaries AuditSummaries
-
 	for _, raw := range raws {
 		auditAction := new(AuditAction)
 		if auditAction.Unmarshal(raw) {
-			auditActions = append(auditActions, *auditAction)
+			yarnReport.AuditActions = append(yarnReport.AuditActions, *auditAction)
 			continue
 		}
 
 		auditAdvisory := new(AuditAdvisory)
 		if auditAdvisory.Unmarshal(raw) {
-			auditAdvisories = append(auditAdvisories, *auditAdvisory)
+			yarnReport.AuditAdvisories = append(yarnReport.AuditAdvisories, *auditAdvisory)
 			continue
 		}
 
 		auditSummary := new(AuditSummary)
 		if auditSummary.Unmarshal(raw) {
-			auditSummaries = append(auditSummaries, *auditSummary)
+			yarnReport.AuditSummaries = append(yarnReport.AuditSummaries, *auditSummary)
 			continue
 		}
 
-		err := errors.New(fmt.Sprintf("Unable to unmarshal JSON into known structure: %s", raw))
+		err := fmt.Errorf("Unable to unmarshal JSON into known structure: %s", raw)
 		return YarnReport{}, err
 	}
-
-	yarnReport := YarnReport{auditActions, auditAdvisories, auditSummaries}
 
 	return yarnReport, nil
 }

--- a/producers/yarn_audit/types/yarn-issue_test.go
+++ b/producers/yarn_audit/types/yarn-issue_test.go
@@ -203,7 +203,7 @@ func TestParseValidReportSummary(t *testing.T) {
 
 	assert.Len(t, *summaries, 1)
 
-	expectedSummaries := []auditSummary{
+	expectedSummaries := []AuditSummary{
 		{
 			Type: "auditSummary",
 			Data: auditSummaryData{
@@ -232,7 +232,7 @@ func TestParseValidReportAdvisories(t *testing.T) {
 
 	assert.Len(t, *advisories, 2)
 
-	expectedAdvisories := []auditAdvisory{
+	expectedAdvisories := []AuditAdvisory{
 		{
 			Type: "auditAdvisory",
 			Data: auditAdvisoryData{
@@ -353,7 +353,7 @@ func TestParseValidReportActions(t *testing.T) {
 
 	assert.Len(t, *actions, 1)
 
-	expectedActions := []auditAction{
+	expectedActions := []AuditAction{
 		{
 			Type: "auditAction",
 			Data: auditActionData{

--- a/producers/yarn_audit/types/yarn-issue_test.go
+++ b/producers/yarn_audit/types/yarn-issue_test.go
@@ -66,7 +66,7 @@ func TestParseCompletelyUnsupportedJSON(t *testing.T) {
 
 // In reality these would be single lines, but for readability in test these should also work
 var fullYarnJSONLines []byte = []byte(
-  `[{
+	`[{
     "type": "auditAdvisory",
     "data": {
       "resolution": {
@@ -297,16 +297,16 @@ func TestParseValidReportAdvisories(t *testing.T) {
 					Cwe: []string{
 						"CWE-918",
 					},
-					FoundBy:         nil,
-					Deleted:         false,
-					ID:              1004946,
-					References:      "- https://advisory1.test.url/Ref1\n- https://advisory1.test.url/Ref2",
-					Created:         "2021-11-18T16:00:48.472Z",
-					ReportedBy:      nil,
-					Title:           "ADVISORY 1 TITLE",
-					NpmAdvisoryID:   nil,
-					Overview:        "Advisory 1 overview",
-					URL:             "https://advisory.1.url",
+					FoundBy:       nil,
+					Deleted:       false,
+					ID:            1004946,
+					References:    "- https://advisory1.test.url/Ref1\n- https://advisory1.test.url/Ref2",
+					Created:       "2021-11-18T16:00:48.472Z",
+					ReportedBy:    nil,
+					Title:         "ADVISORY 1 TITLE",
+					NpmAdvisoryID: nil,
+					Overview:      "Advisory 1 overview",
+					URL:           "https://advisory.1.url",
 				},
 			},
 		},
@@ -351,16 +351,16 @@ func TestParseValidReportAdvisories(t *testing.T) {
 					Cwe: []string{
 						"CWE-920",
 					},
-					FoundBy:         nil,
-					Deleted:         false,
-					ID:              1004947,
-					References:      "- https://advisory2.test.url/Ref1\n- https://advisory2.test.url/Ref2\n- https://advisory2.test.url/Ref3",
-					Created:         "2021-11-18T16:00:48.472Z",
-					ReportedBy:      nil,
-					Title:           "ADVISORY 2 TITLE",
-					NpmAdvisoryID:   nil,
-					Overview:        "Advisory 2 overview",
-					URL:             "https://advisory.2.url",
+					FoundBy:       nil,
+					Deleted:       false,
+					ID:            1004947,
+					References:    "- https://advisory2.test.url/Ref1\n- https://advisory2.test.url/Ref2\n- https://advisory2.test.url/Ref3",
+					Created:       "2021-11-18T16:00:48.472Z",
+					ReportedBy:    nil,
+					Title:         "ADVISORY 2 TITLE",
+					NpmAdvisoryID: nil,
+					Overview:      "Advisory 2 overview",
+					URL:           "https://advisory.2.url",
 				},
 			},
 		},
@@ -415,7 +415,7 @@ func TestParseValidReportAsIssues(t *testing.T) {
 	assert.Len(t, issues, 2)
 
 	expectedIssues := []*v1.Issue{
-		&v1.Issue{
+		{
 			Target:     "advisory1Path: super-awesome-module",
 			Type:       "CWE-918",
 			Title:      "ADVISORY 1 TITLE",
@@ -431,7 +431,7 @@ Advisory URL: https://advisory.1.url
 `,
 			Cve: "CVE-2022-0001",
 		},
-		&v1.Issue{
+		{
 			Target:     "advisory2Path: not-so-awesome-module",
 			Type:       "CWE-920",
 			Title:      "ADVISORY 2 TITLE",

--- a/producers/yarn_audit/types/yarn-issue_test.go
+++ b/producers/yarn_audit/types/yarn-issue_test.go
@@ -13,19 +13,18 @@ var invalidJSON = `Not a valid JSON object`
 
 func TestParseInvalidJSON(t *testing.T) {
 	oneLine := []byte(invalidJSON)
-	report, err := NewReport([][]byte{
-		oneLine,
-		oneLine,
-	})
+	actions, advisories, summaries, err := NewReport(oneLine)
 
-	assert.Nil(t, report)
+	assert.Nil(t, actions)
+	assert.Nil(t, advisories)
+	assert.Nil(t, summaries)
 
-	assert.Len(t, err, 2)
+	assert.NotNil(t, err)
 }
 
 // In reality these would be single lines, but for readability in test these should also work
-var fullYarnJSONLines [][]byte = [][]byte{
-	[]byte(`{
+var fullYarnJSONLines []byte = []byte(
+  `[{
     "type": "auditAdvisory",
     "data": {
       "resolution": {
@@ -63,7 +62,7 @@ var fullYarnJSONLines [][]byte = [][]byte{
         "patched_versions": ">=5.0.1",
         "updated": "2021-09-23T15:45:50.000Z",
         "recommendation": "Upgrade to version 5.0.1 or later",
-        "cwe": "CWE-918",
+        "cwe": ["CWE-918"],
         "found_by": null,
         "deleted": null,
         "id": 1004946,
@@ -76,8 +75,8 @@ var fullYarnJSONLines [][]byte = [][]byte{
         "url": "https://advisory.1.url"
       }
     }
-  }`),
-	[]byte(`{
+  },
+  {
     "type": "unsupported",
     "data": {
       "vulnerabilities": {
@@ -92,8 +91,8 @@ var fullYarnJSONLines [][]byte = [][]byte{
       "optionalDependencies": 0,
       "totalDependencies": 6274
     }
-  }`),
-	[]byte(`{
+  },
+  {
     "type": "auditAdvisory",
     "data": {
       "resolution": {
@@ -131,7 +130,7 @@ var fullYarnJSONLines [][]byte = [][]byte{
         "patched_versions": ">=1.2.0",
         "updated": "2021-09-23T15:45:50.000Z",
         "recommendation": "Upgrade to version 1.2.0 or later",
-        "cwe": "CWE-920",
+        "cwe": ["CWE-920"],
         "found_by": null,
         "deleted": null,
         "id": 1004947,
@@ -144,8 +143,8 @@ var fullYarnJSONLines [][]byte = [][]byte{
         "url": "https://advisory.2.url"
       }
     }
-  }`),
-	[]byte(`{
+  },
+  {
     "type":"auditAction",
     "data":{
       "cmd":"action command",
@@ -166,11 +165,11 @@ var fullYarnJSONLines [][]byte = [][]byte{
         ]
       }
     }
-  }`),
-	[]byte(`{
+  },
+  {
     "completely": "unsupported"
-  }`),
-	[]byte(`{
+  },
+  {
     "type": "auditSummary",
     "data": {
       "vulnerabilities": {
@@ -185,206 +184,211 @@ var fullYarnJSONLines [][]byte = [][]byte{
       "optionalDependencies": 0,
       "totalDependencies": 6274
     }
-  }`),
-}
+  }]`)
 
 func TestParseValidReportContainsAllSupportedFields(t *testing.T) {
-	report, err := NewReport(
-		fullYarnJSONLines,
-	)
+	actions, advisories, summaries, err := NewReport(fullYarnJSONLines)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, report)
 
-	assert.NotNil(t, report.AuditSummary)
-	assert.Len(t, report.AuditAdvisories, 2)
-	assert.Len(t, report.AuditActions, 1)
+	assert.Len(t, *actions, 1)
+	assert.Len(t, *advisories, 2)
+	assert.Len(t, *summaries, 1)
 }
 
 func TestParseValidReportSummary(t *testing.T) {
-	report, err := NewReport(
-		fullYarnJSONLines,
-	)
+	_, _, summaries, err := NewReport(fullYarnJSONLines)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, report)
 
-	assert.NotNil(t, report.AuditSummary)
+	assert.Len(t, *summaries, 1)
 
-	expectedSummaryData := auditSummaryData{
-		Vulnerabilities: vulnerabilities{
-			Info:     1,
-			Low:      10,
-			Moderate: 177,
-			High:     94,
-			Critical: 4,
+	expectedSummaries := []auditSummary{
+		{
+			Type: "auditSummary",
+			Data: auditSummaryData{
+				Vulnerabilities: vulnerabilities{
+					Info:     1,
+					Low:      10,
+					Moderate: 177,
+					High:     94,
+					Critical: 4,
+				},
+				Dependencies:         6274,
+				DevDependencies:      0,
+				OptionalDependencies: 0,
+				TotalDependencies:    6274,
+			},
 		},
-		Dependencies:         6274,
-		DevDependencies:      0,
-		OptionalDependencies: 0,
-		TotalDependencies:    6274,
 	}
 
-	assert.True(t, reflect.DeepEqual(&expectedSummaryData, report.AuditSummary), report.AuditSummary)
+	assert.True(t, reflect.DeepEqual(expectedSummaries, *summaries), *summaries)
 }
 
 func TestParseValidReportAdvisories(t *testing.T) {
-	report, err := NewReport(
-		fullYarnJSONLines,
-	)
+	_, advisories, _, err := NewReport(fullYarnJSONLines)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, report)
 
-	assert.Len(t, report.AuditAdvisories, 2)
+	assert.Len(t, *advisories, 2)
 
-	expectedAdvisories := []*auditAdvisoryData{
+	expectedAdvisories := []auditAdvisory{
 		{
-			Resolution: auditResolution{
-				ID:       1004946,
-				Path:     "advisory1Path",
-				Dev:      false,
-				Optional: false,
-				Bundled:  false,
-			},
-			Advisory: yarnAdvisory{
-				Findings: []finding{
-					{
-						Version: "5.0.0",
-						Paths: []string{
-							"some/path",
-							"another/path",
+			Type: "auditAdvisory",
+			Data: auditAdvisoryData{
+				Resolution: auditResolution{
+					ID:       1004946,
+					Path:     "advisory1Path",
+					Dev:      false,
+					Optional: false,
+					Bundled:  false,
+				},
+				Advisory: yarnAdvisory{
+					Findings: []finding{
+						{
+							Version: "5.0.0",
+							Paths: []string{
+								"some/path",
+								"another/path",
+							},
+						},
+						{
+							Version: "5.0.0",
+							Paths: []string{
+								"more/findings/path",
+							},
 						},
 					},
-					{
-						Version: "5.0.0",
-						Paths: []string{
-							"more/findings/path",
-						},
+					Metadata:           nil,
+					VulnerableVersions: ">2.1.1 <5.0.1",
+					ModuleName:         "super-awesome-module",
+					Severity:           "moderate",
+					GithubAdvisoryID:   "GHSA-93q8-gq69-wqmw",
+					Cves: []string{
+						"CVE-2022-0001",
 					},
+					Access:          "public",
+					PatchedVersions: ">=5.0.1",
+					Updated:         "2021-09-23T15:45:50.000Z",
+					Recommendation:  "Upgrade to version 5.0.1 or later",
+					Cwe: []string{
+						"CWE-918",
+					},
+					FoundBy:         nil,
+					Deleted:         false,
+					ID:              1004946,
+					References:      "- https://advisory1.test.url/Ref1\n- https://advisory1.test.url/Ref2",
+					Created:         "2021-11-18T16:00:48.472Z",
+					ReportedBy:      nil,
+					Title:           "ADVISORY 1 TITLE",
+					NpmAdvisoryID:   nil,
+					Overview:        "Advisory 1 overview",
+					URL:             "https://advisory.1.url",
 				},
-				Metadata:           nil,
-				VulnerableVersions: ">2.1.1 <5.0.1",
-				ModuleName:         "super-awesome-module",
-				Severity:           "moderate",
-				GithubAdvisoryID:   "GHSA-93q8-gq69-wqmw",
-				Cves: []string{
-					"CVE-2022-0001",
-				},
-				Access:          "public",
-				PatchedVersions: ">=5.0.1",
-				Updated:         "2021-09-23T15:45:50.000Z",
-				Recommendation:  "Upgrade to version 5.0.1 or later",
-				Cwe:             "CWE-918",
-				FoundBy:         nil,
-				Deleted:         false,
-				ID:              1004946,
-				References:      "- https://advisory1.test.url/Ref1\n- https://advisory1.test.url/Ref2",
-				Created:         "2021-11-18T16:00:48.472Z",
-				ReportedBy:      nil,
-				Title:           "ADVISORY 1 TITLE",
-				NpmAdvisoryID:   nil,
-				Overview:        "Advisory 1 overview",
-				URL:             "https://advisory.1.url",
 			},
 		},
 		{
-			Resolution: auditResolution{
-				ID:       1004947,
-				Path:     "advisory2Path",
-				Dev:      true,
-				Optional: false,
-				Bundled:  false,
-			},
-			Advisory: yarnAdvisory{
-				Findings: []finding{
-					{
-						Version: "1.1.0",
-						Paths: []string{
-							"some/path",
-							"another/path",
+			Type: "auditAdvisory",
+			Data: auditAdvisoryData{
+				Resolution: auditResolution{
+					ID:       1004947,
+					Path:     "advisory2Path",
+					Dev:      true,
+					Optional: false,
+					Bundled:  false,
+				},
+				Advisory: yarnAdvisory{
+					Findings: []finding{
+						{
+							Version: "1.1.0",
+							Paths: []string{
+								"some/path",
+								"another/path",
+							},
+						},
+						{
+							Version: "1.1.0",
+							Paths: []string{
+								"more/findings/path",
+							},
 						},
 					},
-					{
-						Version: "1.1.0",
-						Paths: []string{
-							"more/findings/path",
-						},
+					Metadata:           nil,
+					VulnerableVersions: ">1.1.1 <1.2.0",
+					ModuleName:         "not-so-awesome-module",
+					Severity:           "low",
+					GithubAdvisoryID:   "GHSA-93q8-gq69-wqmw",
+					Cves: []string{
+						"CVE-2022-0002",
 					},
+					Access:          "public",
+					PatchedVersions: ">=1.2.0",
+					Updated:         "2021-09-23T15:45:50.000Z",
+					Recommendation:  "Upgrade to version 1.2.0 or later",
+					Cwe: []string{
+						"CWE-920",
+					},
+					FoundBy:         nil,
+					Deleted:         false,
+					ID:              1004947,
+					References:      "- https://advisory2.test.url/Ref1\n- https://advisory2.test.url/Ref2\n- https://advisory2.test.url/Ref3",
+					Created:         "2021-11-18T16:00:48.472Z",
+					ReportedBy:      nil,
+					Title:           "ADVISORY 2 TITLE",
+					NpmAdvisoryID:   nil,
+					Overview:        "Advisory 2 overview",
+					URL:             "https://advisory.2.url",
 				},
-				Metadata:           nil,
-				VulnerableVersions: ">1.1.1 <1.2.0",
-				ModuleName:         "not-so-awesome-module",
-				Severity:           "low",
-				GithubAdvisoryID:   "GHSA-93q8-gq69-wqmw",
-				Cves: []string{
-					"CVE-2022-0002",
-				},
-				Access:          "public",
-				PatchedVersions: ">=1.2.0",
-				Updated:         "2021-09-23T15:45:50.000Z",
-				Recommendation:  "Upgrade to version 1.2.0 or later",
-				Cwe:             "CWE-920",
-				FoundBy:         nil,
-				Deleted:         false,
-				ID:              1004947,
-				References:      "- https://advisory2.test.url/Ref1\n- https://advisory2.test.url/Ref2\n- https://advisory2.test.url/Ref3",
-				Created:         "2021-11-18T16:00:48.472Z",
-				ReportedBy:      nil,
-				Title:           "ADVISORY 2 TITLE",
-				NpmAdvisoryID:   nil,
-				Overview:        "Advisory 2 overview",
-				URL:             "https://advisory.2.url",
 			},
 		},
 	}
 
-	assert.True(t, reflect.DeepEqual(expectedAdvisories, report.AuditAdvisories), report.AuditAdvisories)
+	assert.True(t, reflect.DeepEqual(expectedAdvisories, *advisories), *advisories)
 }
 
 func TestParseValidReportActions(t *testing.T) {
-	report, err := NewReport(
-		fullYarnJSONLines,
-	)
+	actions, _, _, err := NewReport(fullYarnJSONLines)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, report)
 
-	assert.Len(t, report.AuditActions, 1)
+	assert.Len(t, *actions, 1)
 
-	expectedActionData := auditActionData{
-		Cmd:        "action command",
-		IsBreaking: false,
-		Action: auditAction{
-			Action:  "action string",
-			Module:  "action module string",
-			Target:  "action target",
-			IsMajor: true,
-			Resolves: []auditResolution{
-				{
-					ID:       1,
-					Path:     "action reolve path",
-					Dev:      true,
-					Optional: true,
-					Bundled:  true,
+	expectedActions := []auditAction{
+		{
+			Type: "auditAction",
+			Data: auditActionData{
+				Cmd:        "action command",
+				IsBreaking: false,
+				Action: auditActionAction{
+					Action:  "action string",
+					Module:  "action module string",
+					Target:  "action target",
+					IsMajor: true,
+					Resolves: []auditResolution{
+						{
+							ID:       1,
+							Path:     "action reolve path",
+							Dev:      true,
+							Optional: true,
+							Bundled:  true,
+						},
+					},
 				},
 			},
 		},
 	}
 
-	assert.True(t, reflect.DeepEqual(&expectedActionData, report.AuditActions[0]), report.AuditActions[0])
+	assert.True(t, reflect.DeepEqual(expectedActions, *actions), *actions)
 }
 
 func TestParseValidReportAsIssues(t *testing.T) {
-	report, err := NewReport(
-		fullYarnJSONLines,
-	)
+	_, advisories, _, err := NewReport(fullYarnJSONLines)
 
 	assert.Nil(t, err)
 
-	assert.Len(t, report.AuditAdvisories, 2)
+	assert.Len(t, *advisories, 2)
 
-	issues := report.AsIssues()
+	issues := AsIssues(advisories)
 	assert.Len(t, issues, 2)
 
 	expectedIssues := []*v1.Issue{


### PR DESCRIPTION
The existing yarn-audit producer fails due to odd golang behaviour that mangles the contents of `[][]byte` structures. This is a rewrite of the yarn-audit producer to instead read input into a `[]byte` structure, similar to the npm-audit producer, which is not mangled in the same way.

This PR also:
- updates the README to reflect the necessary use of `jq` on `yarn audit` output to get a JSON array back
- updates the auditAdvisory struct to accept arrays of CWEs, as provided by `yarn audit`
- rewrites existing tests to fit the new structure