### PR TITLE
Handle enrichment DB entries without CVEs

### DIFF
--- a/pkg/enrichment/db/issue.go
+++ b/pkg/enrichment/db/issue.go
@@ -24,7 +24,7 @@ type issue struct {
 	Confidence  int32   		`db:"confidence"`
 	Description string  		`db:"description"`
 	Source      string  		`db:"source"`
-	CVE         sql.NullString  `db:"cve"`
+	CVE         sql.NullString	`db:"cve"`
 }
 
 func toDBIssue(i *v1.EnrichedIssue) (*issue, error) {

--- a/pkg/enrichment/db/issue.go
+++ b/pkg/enrichment/db/issue.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
@@ -15,15 +16,15 @@ type issue struct {
 	FalsePositive bool      `db:"false_positive"`
 	UpdatedAt     time.Time `db:"updated_at"`
 
-	Target      string  `db:"target"`
-	Type        string  `db:"type"`
-	Title       string  `db:"title"`
-	Severity    int32   `db:"severity"`
-	CVSS        float64 `db:"cvss"`
-	Confidence  int32   `db:"confidence"`
-	Description string  `db:"description"`
-	Source      string  `db:"source"`
-	CVE         string  `db:"cve"`
+	Target      string  		`db:"target"`
+	Type        string  		`db:"type"`
+	Title       string  		`db:"title"`
+	Severity    int32   		`db:"severity"`
+	CVSS        float64 		`db:"cvss"`
+	Confidence  int32   		`db:"confidence"`
+	Description string  		`db:"description"`
+	Source      string  		`db:"source"`
+	CVE         sql.NullString  `db:"cve"`
 }
 
 func toDBIssue(i *v1.EnrichedIssue) (*issue, error) {
@@ -35,6 +36,7 @@ func toDBIssue(i *v1.EnrichedIssue) (*issue, error) {
 	if err != nil {
 		return nil, err
 	}
+	cve := sql.NullString{String: i.RawIssue.GetCve(), Valid: true}
 	return &issue{
 		Hash:          i.GetHash(),
 		FirstSeen:     firstSeen,
@@ -49,7 +51,7 @@ func toDBIssue(i *v1.EnrichedIssue) (*issue, error) {
 		Confidence:    int32(i.RawIssue.GetConfidence()),
 		Description:   i.RawIssue.GetDescription(),
 		Source:        i.RawIssue.GetSource(),
-		CVE:           i.RawIssue.GetCve(),
+		CVE:           cve,
 	}, nil
 }
 
@@ -63,6 +65,15 @@ func toEnrichedIssue(i *issue) (*v1.EnrichedIssue, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Handle DBIssues with NULL CVE field
+	var cve string
+	if (i.CVE.Valid) {
+		cve = i.CVE.String
+	} else {
+		cve = ""
+	}
+
 	return &v1.EnrichedIssue{
 		Hash:          i.Hash,
 		FirstSeen:     firstSeen,
@@ -78,7 +89,7 @@ func toEnrichedIssue(i *issue) (*v1.EnrichedIssue, error) {
 			Confidence:  v1.Confidence(i.Confidence),
 			Description: i.Description,
 			Source:      i.Source,
-			Cve:         i.CVE,
+			Cve:         cve,
 		},
 	}, nil
 }

--- a/pkg/enrichment/db/issue.go
+++ b/pkg/enrichment/db/issue.go
@@ -16,15 +16,15 @@ type issue struct {
 	FalsePositive bool      `db:"false_positive"`
 	UpdatedAt     time.Time `db:"updated_at"`
 
-	Target      string  		`db:"target"`
-	Type        string  		`db:"type"`
-	Title       string  		`db:"title"`
-	Severity    int32   		`db:"severity"`
-	CVSS        float64 		`db:"cvss"`
-	Confidence  int32   		`db:"confidence"`
-	Description string  		`db:"description"`
-	Source      string  		`db:"source"`
-	CVE         sql.NullString	`db:"cve"`
+	Target      string         `db:"target"`
+	Type        string         `db:"type"`
+	Title       string         `db:"title"`
+	Severity    int32          `db:"severity"`
+	CVSS        float64        `db:"cvss"`
+	Confidence  int32          `db:"confidence"`
+	Description string         `db:"description"`
+	Source      string         `db:"source"`
+	CVE         sql.NullString `db:"cve"`
 }
 
 func toDBIssue(i *v1.EnrichedIssue) (*issue, error) {
@@ -67,11 +67,9 @@ func toEnrichedIssue(i *issue) (*v1.EnrichedIssue, error) {
 	}
 
 	// Handle DBIssues with NULL CVE field
-	var cve string
+	cve := ""
 	if (i.CVE.Valid) {
 		cve = i.CVE.String
-	} else {
-		cve = ""
 	}
 
 	return &v1.EnrichedIssue{


### PR DESCRIPTION
Entries in the enrichment DB added before the change to record CVEs have NULL values in the CVE column. This is not handled by the string type, resulting in errors trying to convert existing DB issues to enriched issues. This PR changes the CVE field in the DB issue struct to be sql.NullString, which does have handling for NULL values.