### PR TITLE
`yarn audit` producer: unconditionally write results file

### DIFF
--- a/producers/yarn_audit/main.go
+++ b/producers/yarn_audit/main.go
@@ -22,12 +22,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if yarnReport.AuditAdvisories != nil {
-		if err := producers.WriteDraconOut(
-			"yarn-audit",
-			yarnReport.AuditAdvisories.AsIssues(),
-		); err != nil {
-			log.Fatal(err)
-		}
+	if err := producers.WriteDraconOut(
+		"yarn-audit",
+		yarnReport.AuditAdvisories.AsIssues(),
+	); err != nil {
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
The enricher always expects producers that run before it to output results files, even if the producer found no issues to report. This isn't the case with the `yarn audit` producer - a results file is only written if at least one issue was found.

Write a results file regardless of how many issues were found by the producer.

Fixes #144.