### PR TITLE
Fix to handle empty YAML documents

### DIFF
--- a/pkg/template/load.go
+++ b/pkg/template/load.go
@@ -95,11 +95,13 @@ func splitYAML(targetYAML []byte) ([][]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		valueBytes, err := goyaml.Marshal(value)
-		if err != nil {
-			return nil, err
+		if value != nil {
+			valueBytes, err := goyaml.Marshal(value)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, valueBytes)
 		}
-		res = append(res, valueBytes)
 	}
 	return res, nil
 }

--- a/pkg/template/load_test.go
+++ b/pkg/template/load_test.go
@@ -35,6 +35,28 @@ func TestSplitYAML(t *testing.T) {
 			err: nil,
 		},
 		{
+			desc: "a simple YAML file with two leading document separators",
+			inBytes: []byte(heredoc.Doc(`
+			---
+			---
+			a: Easy
+			b:
+			    c: 2
+			    d:
+			        - 3
+			        - 4
+			`)),
+			outBytes: [][]byte{[]byte(heredoc.Doc(`
+			a: Easy
+			b:
+			    c: 2
+			    d:
+			        - 3
+			        - 4
+			`))},
+			err: nil,
+		},
+		{
 			desc: "a simple YAML file with a leading document separator",
 			inBytes: []byte(heredoc.Doc(`
 			---


### PR DESCRIPTION
Small commit so that empty YAML documents in a multi-doc YAML file are handled properly (they are currently converted to `nil` elements in the list which could be handled improperly).